### PR TITLE
fix: decode revert reason

### DIFF
--- a/extension/src/utils/decodeRolesError.ts
+++ b/extension/src/utils/decodeRolesError.ts
@@ -1,3 +1,6 @@
+import { ethers } from 'ethers'
+import { toUtf8String } from 'ethers/lib/utils'
+
 import { JsonRpcError } from '../types'
 import { Permissions__factory, Roles__factory } from '../types/typechain'
 
@@ -37,7 +40,7 @@ export default function decodeRolesError(error: JsonRpcError) {
       )
     if (error) return error
 
-    return asciiDecode(revertData.substring(2))
+    return decodeRevertReason(revertData)
   }
 
   return message
@@ -47,10 +50,9 @@ export const isPermissionsError = (decodedError: string) =>
   KNOWN_ERRORS.includes(decodedError) &&
   decodedError !== 'ModuleTransactionFailed()'
 
-function asciiDecode(hex: string) {
-  let result = ''
-  for (let i = 0; i < hex.length; i += 2) {
-    result += String.fromCharCode(parseInt(hex.substring(i, i + 2), 16))
-  }
-  return result
+function decodeRevertReason(hex: string) {
+  // Take the revert reason from the error code
+  // See https://ethereum.stackexchange.com/a/66173
+  const codeString = `0x${hex.substring(138)}`
+  return toUtf8String(codeString)
 }


### PR DESCRIPTION
This fixes a decoding issue for revert error messages.

With the fix we only decode the revert reason part of the revert code. A revert code is structured as follows:

```
0x08c379a0                                                       // Function selector
0000000000000000000000000000000000000000000000000000000000000020 // Offset of string return value
0000000000000000000000000000000000000000000000000000000000000047 // Length of string return value (the revert reason)
6d7946756e6374696f6e206f6e6c79206163636570747320617267756d656e74 // first 32 bytes of the revert reason
7320776869636820617265206772656174686572207468616e206f7220657175 // next 32 bytes of the revert reason
616c20746f203500000000000000000000000000000000000000000000000000 // last 7 bytes of the revert reason
```

Before:
<img width="717" alt="Screenshot 2023-01-18 at 16 52 15" src="https://user-images.githubusercontent.com/1248066/213221845-90d6efb5-076a-4e72-8fe1-38db6fa55420.png">

After:
<img width="714" alt="Screenshot 2023-01-18 at 16 51 00" src="https://user-images.githubusercontent.com/1248066/213221925-374e3091-dfc1-4d69-9c12-86b7abf5d262.png">