### PR TITLE
Add Chain select field to connection setup UI

### DIFF
--- a/extension/.cspell.json
+++ b/extension/.cspell.json
@@ -32,6 +32,7 @@
     "metavault",
     "multicall",
     "multisend",
+    "Numberish",
     "Omni",
     "outdir",
     "paraswap",

--- a/extension/src/browser/Drawer/index.tsx
+++ b/extension/src/browser/Drawer/index.tsx
@@ -13,7 +13,7 @@ import { useAllTransactions, useDispatch, useNewTransactions } from '../state'
 import Submit from './Submit'
 import { Transaction, TransactionBadge } from './Transaction'
 import classes from './style.module.css'
-import { ChainId, MULTI_SEND_ADDRESS } from '../../chains'
+import { MULTI_SEND_ADDRESS } from '../../chains'
 
 const TransactionsDrawer: React.FC = () => {
   const [expanded, setExpanded] = useState(true)
@@ -21,7 +21,7 @@ const TransactionsDrawer: React.FC = () => {
   const newTransactions = useNewTransactions()
   const dispatch = useDispatch()
   const provider = useProvider()
-  const { connection, chainId } = useConnection()
+  const { connection } = useConnection()
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
 
@@ -59,12 +59,12 @@ const TransactionsDrawer: React.FC = () => {
   }
 
   const copyTransactionData = () => {
-    if (!chainId) throw new Error('chainId is undefined')
+    if (!connection.chainId) throw new Error('chainId is undefined')
     const metaTransactions = newTransactions.map((tx) => encodeSingle(tx.input))
     const batchTransaction =
       metaTransactions.length === 1
         ? metaTransactions[0]
-        : encodeMulti(metaTransactions, MULTI_SEND_ADDRESS[chainId as ChainId])
+        : encodeMulti(metaTransactions, MULTI_SEND_ADDRESS[connection.chainId])
     const finalRequest = connection.moduleAddress
       ? wrapRequest(batchTransaction, connection)
       : batchTransaction

--- a/extension/src/connections/ConnectionsDrawer/ChainSelect/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/ChainSelect/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { ChainId, CHAIN_NAME } from '../../../chains'
+import { Select } from '../../../components'
+
+import classes from './style.module.css'
+
+export interface Props {
+  value: ChainId
+  onChange(chainId: ChainId): void
+}
+
+interface Option {
+  value: ChainId
+  label: string
+}
+
+const options = Object.entries(CHAIN_NAME).map(([chainId, name]) => ({
+  value: parseInt(chainId),
+  label: name,
+}))
+
+const ChainSelect: React.FC<Props> = ({ value, onChange }) => {
+  const ChainOptionLabel: React.FC<Option> = ({ value, label }) => (
+    <div className={classes.chainOption}>
+      <div className={classes.chainLabel}>{label || `#${value}`}</div>
+    </div>
+  )
+
+  return (
+    <Select
+      options={options}
+      value={options.find((op) => op.value === value)}
+      onChange={(option: any) => onChange(option.value)}
+      formatOptionLabel={ChainOptionLabel as any}
+    />
+  )
+}
+
+export default ChainSelect

--- a/extension/src/connections/ConnectionsDrawer/ChainSelect/style.module.css
+++ b/extension/src/connections/ConnectionsDrawer/ChainSelect/style.module.css
@@ -1,0 +1,12 @@
+.chainOption {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 0;
+}
+
+.chainLabel {
+  font-family: 'Spectra';
+  font-size: 1rem;
+  padding-left: 4px;
+}

--- a/extension/src/connections/ConnectionsDrawer/ConnectButton/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/ConnectButton/index.tsx
@@ -112,22 +112,9 @@ const ConnectButton: React.FC<{ id: string }> = ({ id }) => {
         <Tag head={<RiAlertLine />} color="warning">
           Chain mismatch
         </Tag>
-        {walletConnect.chainId && (
-          <Button
-            className={classes.disconnectButton}
-            onClick={() => {
-              connect(
-                ProviderType.WalletConnect,
-                walletConnect.chainId as ChainId,
-                connection.pilotAddress
-              )
-            }}
-          >
-            Connect to{' '}
-            {CHAIN_NAME[walletConnect.chainId as ChainId] ||
-              `#${walletConnect.chainId}`}
-          </Button>
-        )}
+        <Button onClick={disconnect} className={classes.disconnectButton}>
+          Disconnect
+        </Button>
       </div>
     )
   }
@@ -170,7 +157,7 @@ const ConnectButton: React.FC<{ id: string }> = ({ id }) => {
           </Button>
         )}
 
-        {metamask.chainId && (
+        {/* {metamask.chainId && (
           <Button
             className={classes.disconnectButton}
             onClick={() => {
@@ -184,7 +171,7 @@ const ConnectButton: React.FC<{ id: string }> = ({ id }) => {
             Connect to{' '}
             {CHAIN_NAME[metamask.chainId as ChainId] || `#${metamask.chainId}`}
           </Button>
-        )}
+        )} */}
       </div>
     )
   }

--- a/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
@@ -25,6 +25,8 @@ import { useClearTransactions } from '../../../browser/state/transactionHooks'
 
 import classes from './style.module.css'
 import { decodeRoleKey, encodeRoleKey } from '../../../utils'
+import { ChainId } from '../../../chains'
+import ChainSelect from '../ChainSelect'
 
 interface Props {
   connectionId: string
@@ -37,6 +39,7 @@ type ConnectionPatch = {
   moduleAddress?: string
   moduleType?: SupportedModuleType
   roleId?: string
+  chainId?: ChainId
 }
 
 const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
@@ -200,6 +203,12 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
                     label: ev.target.value,
                   })
                 }}
+              />
+            </Field>
+            <Field label="Chain">
+              <ChainSelect
+                value={connection.chainId}
+                onChange={(chainId) => updateConnection({ chainId })}
               />
             </Field>
             <Field label="Pilot Account" labelFor="">

--- a/extension/src/connections/connectionHooks.tsx
+++ b/extension/src/connections/connectionHooks.tsx
@@ -142,7 +142,7 @@ export const useConnection = (id?: string) => {
     connection.chainId
   )
 
-  const chainId =
+  const providerChainId =
     connection.providerType === ProviderType.MetaMask
       ? metamask.chainId
       : walletConnect?.chainId || null
@@ -169,7 +169,7 @@ export const useConnection = (id?: string) => {
   }, [mustConnectMetaMask, connectMetaMask])
 
   const connect = useCallback(async () => {
-    if (requiredChainId && chainId !== requiredChainId) {
+    if (requiredChainId && providerChainId !== requiredChainId) {
       try {
         await switchChain(requiredChainId)
       } catch (e) {
@@ -179,13 +179,15 @@ export const useConnection = (id?: string) => {
     }
 
     return true
-  }, [switchChain, chainId, requiredChainId])
+  }, [switchChain, providerChainId, requiredChainId])
 
   return {
     connection,
     provider,
+    /** Indicates if `provider` is connected to the chain set in `connection`. */
     connected,
-    chainId,
+    /** The chain ID the `provider` is currently connected to. Might be different the the chainId configured for `connection` */
+    providerChainId,
 
     /** If this callback is set, it can be invoked to establish a connection to the Pilot wallet by asking the user to switch it to the right chain. */
     connect: canEstablishConnection ? connect : null,

--- a/extension/src/connections/useZodiacModules.ts
+++ b/extension/src/connections/useZodiacModules.ts
@@ -1,4 +1,3 @@
-import { JsonRpcBatchProvider } from '@ethersproject/providers'
 import {
   ContractAbis,
   ContractAddresses,
@@ -13,7 +12,6 @@ import { useEffect, useState } from 'react'
 
 import { validateAddress } from '../utils'
 import { useConnection } from './connectionHooks'
-import { ChainId, RPC } from '../chains'
 import { getReadOnlyProvider } from '../providers/readOnlyProvider'
 
 const SUPPORTED_MODULES = [
@@ -41,12 +39,11 @@ export const useZodiacModules = (
   const [error, setError] = useState(false)
   const [modules, setModules] = useState<Module[]>([])
 
-  const { chainId } = useConnection(connectionId)
+  const { connection } = useConnection(connectionId)
+  const chainId = connection.chainId
 
   useEffect(() => {
-    if (!chainId) return
-    const provider = getReadOnlyProvider(chainId as ChainId)
-
+    const provider = getReadOnlyProvider(chainId)
     setLoading(true)
     setError(false)
     fetchModules(safeAddress, provider)

--- a/extension/src/providers/ProvideTenderly.tsx
+++ b/extension/src/providers/ProvideTenderly.tsx
@@ -69,8 +69,8 @@ async function prepareSafeForSimulation(
   }: {
     chainId: ChainId
     avatarAddress: string
-    moduleAddress: string
-    pilotAddress: string
+    moduleAddress?: string
+    pilotAddress?: string
   },
   tenderlyProvider: TenderlyProvider
 ) {
@@ -83,8 +83,11 @@ async function prepareSafeForSimulation(
       safe.getThreshold(),
     ])
 
+    // default to first owner if no pilot address is provided
+    if (!pilotAddress) pilotAddress = owners[0]
+
     const pilotIsOwner = owners.some(
-      (owner) => owner.toLowerCase() === pilotAddress.toLowerCase()
+      (owner) => owner.toLowerCase() === pilotAddress!.toLowerCase()
     )
 
     if (!pilotIsOwner) {

--- a/extension/src/providers/readOnlyProvider.ts
+++ b/extension/src/providers/readOnlyProvider.ts
@@ -5,6 +5,7 @@ import {
   TransactionRequest,
 } from '@ethersproject/providers'
 import { ChainId, RPC } from '../chains'
+import { BigNumberish } from 'ethers'
 
 const readOnlyProviderCache = new Map<ChainId, StaticJsonRpcProvider>()
 const eip1193ProviderCache = new Map<string, Eip1193JsonRpcProvider>()
@@ -42,12 +43,21 @@ export const getEip1193ReadOnlyProvider = (
   return provider
 }
 
-const hexlifyTransaction = (transaction: TransactionRequest) =>
-  StaticJsonRpcProvider.hexlifyTransaction(transaction, {
+const hexlifyTransaction = ({
+  gas,
+  gasLimit,
+  ...rest
+}: TransactionRequest & { gas?: BigNumberish }) => {
+  const tx = {
+    ...rest,
+    gasLimit: gasLimit || gas,
+  }
+  return StaticJsonRpcProvider.hexlifyTransaction(tx, {
     from: true,
     customData: true,
     ccipReadEnabled: true,
   })
+}
 
 /**
  * Based on the ethers v5 Eip1193Bridge (https://github.com/ethers-io/ethers.js/blob/v5.7/packages/experimental/src.ts/eip1193-bridge.ts)

--- a/extension/src/providers/useWalletConnect.ts
+++ b/extension/src/providers/useWalletConnect.ts
@@ -139,7 +139,7 @@ const useWalletConnect = (connectionId: string): WalletConnectResult | null => {
     provider ? provider.connected : false
   )
   const [accounts, setAccounts] = useState(provider ? provider.accounts : [])
-  const [chainId, setChainId] = useState(provider?.chainId)
+  const [chainId, setChainId] = useState<number | undefined>()
 
   // effect to initialize the provider
   useEffect(() => {

--- a/extension/src/safe/useSafeDelegates.ts
+++ b/extension/src/safe/useSafeDelegates.ts
@@ -10,7 +10,10 @@ export const useSafeDelegates = (
   safeAddress: string,
   connectionId?: string
 ) => {
-  const { provider, chainId } = useConnection(connectionId)
+  const {
+    provider,
+    connection: { chainId },
+  } = useConnection(connectionId)
 
   const [loading, setLoading] = useState(false)
   const [delegates, setDelegates] = useState<string[]>([])

--- a/extension/src/safe/useSafesWithOwner.ts
+++ b/extension/src/safe/useSafesWithOwner.ts
@@ -10,7 +10,9 @@ export const useSafesWithOwner = (
   ownerAddress: string,
   connectionId?: string
 ) => {
-  const { chainId } = useConnection(connectionId)
+  const {
+    connection: { chainId },
+  } = useConnection(connectionId)
 
   const [loading, setLoading] = useState(false)
   const [safes, setSafes] = useState<string[]>([])

--- a/extension/src/utils/decodeError.ts
+++ b/extension/src/utils/decodeError.ts
@@ -7,13 +7,6 @@ const RolesV1PermissionsInterface =
   ContractFactories[KnownContracts.PERMISSIONS].createInterface()
 const RolesV2Interface =
   ContractFactories[KnownContracts.ROLES_V2].createInterface()
-console.log(
-  Object.keys(RolesV2Interface.errors).map((errSig) => ({
-    errSig,
-    sigHash: RolesV2Interface.getSighash(errSig),
-    error: RolesV2Interface.errors[errSig],
-  }))
-)
 
 export function getRevertData(error: JsonRpcError) {
   // The errors thrown when a transaction is reverted use different formats, depending on:


### PR DESCRIPTION
This PR adds a field for setting the chain of a connection. So far we retrieved it from the connected wallet (metamask/walletconnect). Making it more explicit might clear confusions and surface problems when connected to wrong chains.

