### PR TITLE
Launch with unconnected Pilot wallet

### DIFF
--- a/extension/.cspell.json
+++ b/extension/.cspell.json
@@ -32,6 +32,7 @@
     "metavault",
     "multicall",
     "multisend",
+    "Numberish",
     "Omni",
     "outdir",
     "paraswap",

--- a/extension/src/app.tsx
+++ b/extension/src/app.tsx
@@ -27,9 +27,7 @@ const Routes: React.FC = () => {
   const { connection } = useConnection()
 
   const isConnectionsRoute = connectionsRouteMatch.isMatch
-  const connectionChangeRequired =
-    !validateAddress(connection.avatarAddress) ||
-    !validateAddress(connection.pilotAddress)
+  const connectionChangeRequired = !validateAddress(connection.avatarAddress)
 
   const [connections] = useConnections()
   const connectionToEdit =

--- a/extension/src/bridge/SafeAppBridge.ts
+++ b/extension/src/bridge/SafeAppBridge.ts
@@ -55,7 +55,7 @@ export default class SafeAppBridge {
 
     this.connection = connection
     const href = await requestIframeHref()
-    const currentOrigin = href ? new URL(href).host : undefined
+    const currentOrigin = href && new URL(href).origin
 
     const isConnected =
       this.connectedOrigin && currentOrigin === this.connectedOrigin

--- a/extension/src/browser/Drawer/Submit.tsx
+++ b/extension/src/browser/Drawer/Submit.tsx
@@ -136,6 +136,7 @@ const Submit: React.FC = () => {
         <Button
           onClick={connectWallet}
           disabled={!submitTransactions || transactions.length === 0}
+          secondary
         >
           Connect wallet to submit
         </Button>

--- a/extension/src/browser/Drawer/Submit.tsx
+++ b/extension/src/browser/Drawer/Submit.tsx
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify'
 
 import { Button, IconButton } from '../../components'
 import toastClasses from '../../components/Toast/Toast.module.css'
-import { ChainId, EXPLORER_URL, CHAIN_PREFIX } from '../../chains'
+import { ChainId, EXPLORER_URL, CHAIN_PREFIX, CHAIN_NAME } from '../../chains'
 import { waitForMultisigExecution } from '../../providers'
 // import { shallExecuteDirectly } from '../../safe/sendTransaction'
 import { useConnection } from '../../connections'
@@ -20,11 +20,13 @@ import { useDispatch, useNewTransactions } from '../state'
 
 import classes from './style.module.css'
 import { getReadOnlyProvider } from '../../providers/readOnlyProvider'
+import { usePushConnectionsRoute } from '../../routing'
 
 const Submit: React.FC = () => {
-  const { connection } = useConnection()
+  const { connection, connect, connected } = useConnection()
   const { chainId, pilotAddress, providerType } = connection
   const dispatch = useDispatch()
+  const pushConnectionsRoute = usePushConnectionsRoute()
 
   const transactions = useNewTransactions()
   const submitTransactions = useSubmitTransactions()
@@ -41,7 +43,24 @@ const Submit: React.FC = () => {
   //   }
   // }, [provider, connection])
 
+  const connectWallet = () => {
+    pushConnectionsRoute(connection.id)
+  }
+
   const submit = async () => {
+    if (!connected) {
+      if (!connect) throw new Error('invariant violation')
+
+      const success = await connect()
+      if (!success) {
+        const chainName = CHAIN_NAME[chainId] || `#${chainId}`
+        toast.error(
+          `Switch your wallet to ${chainName} to submit the transactions`
+        )
+        return
+      }
+    }
+
     if (!submitTransactions) throw new Error('invariant violation')
     setSignaturePending(true)
     let batchTransactionHash: string
@@ -104,12 +123,24 @@ const Submit: React.FC = () => {
 
   return (
     <>
-      <Button
-        onClick={submit}
-        disabled={!submitTransactions || transactions.length === 0}
-      >
-        Submit
-      </Button>
+      {(connected || !!connect) && (
+        <Button
+          onClick={submit}
+          disabled={!submitTransactions || transactions.length === 0}
+        >
+          Submit
+        </Button>
+      )}
+
+      {!connected && !connect && (
+        <Button
+          onClick={connectWallet}
+          disabled={!submitTransactions || transactions.length === 0}
+        >
+          Connect wallet to submit
+        </Button>
+      )}
+
       {signaturePending && (
         <AwaitingSignatureModal
           isOpen={signaturePending}

--- a/extension/src/browser/Drawer/Transaction.tsx
+++ b/extension/src/browser/Drawer/Transaction.tsx
@@ -128,8 +128,10 @@ export const Transaction: React.FC<Props> = ({
   const { connection } = useConnection()
   const elementRef = useScrollIntoView(scrollIntoView)
   const showRoles =
-    connection.moduleType === KnownContracts.ROLES_V1 ||
-    connection.moduleType === KnownContracts.ROLES_V2
+    (connection.moduleType === KnownContracts.ROLES_V1 ||
+      connection.moduleType === KnownContracts.ROLES_V2) &&
+    !!connection.roleId &&
+    !!connection.pilotAddress // TODO remove this check once we can query role members via ser to get a fallback
 
   return (
     <Box ref={elementRef} p={2} className={classes.container}>

--- a/extension/src/browser/Drawer/index.tsx
+++ b/extension/src/browser/Drawer/index.tsx
@@ -3,7 +3,14 @@ import { RiFileCopy2Line, RiRefreshLine } from 'react-icons/ri'
 import { encodeMulti, encodeSingle } from 'react-multisend'
 import { toast } from 'react-toastify'
 
-import { BlockButton, Box, Drawer, Flex, IconButton } from '../../components'
+import {
+  BlockButton,
+  Box,
+  Button,
+  Drawer,
+  Flex,
+  IconButton,
+} from '../../components'
 import { ForkProvider } from '../../providers'
 import { wrapRequest } from '../../providers/WrappingProvider'
 import { useConnection } from '../../connections'
@@ -166,9 +173,18 @@ const TransactionsDrawer: React.FC = () => {
             </p>
           )}
         </Flex>
-        <Box p={2} bg>
+        <Flex justifyContent="space-between" gap={2}>
+          {!connection.pilotAddress && (
+            <Button
+              secondary
+              onClick={copyTransactionData}
+              disabled={newTransactions.length === 0}
+            >
+              Copy transaction data
+            </Button>
+          )}
           <Submit />
-        </Box>
+        </Flex>
       </Flex>
     </Drawer>
   )

--- a/extension/src/browser/Drawer/index.tsx
+++ b/extension/src/browser/Drawer/index.tsx
@@ -3,14 +3,7 @@ import { RiFileCopy2Line, RiRefreshLine } from 'react-icons/ri'
 import { encodeMulti, encodeSingle } from 'react-multisend'
 import { toast } from 'react-toastify'
 
-import {
-  BlockButton,
-  Box,
-  Button,
-  Drawer,
-  Flex,
-  IconButton,
-} from '../../components'
+import { BlockButton, Button, Drawer, Flex, IconButton } from '../../components'
 import { ForkProvider } from '../../providers'
 import { wrapRequest } from '../../providers/WrappingProvider'
 import { useConnection } from '../../connections'

--- a/extension/src/browser/Drawer/style.module.css
+++ b/extension/src/browser/Drawer/style.module.css
@@ -238,6 +238,10 @@ button.link:hover {
   left: 0;
 }
 
+.secondaryButton {
+  background: none;
+}
+
 @-webkit-keyframes pulse {
   to {
     box-shadow: 0 0 0 8px rgba(232, 76, 61, 0);

--- a/extension/src/browser/ProvideProvider.tsx
+++ b/extension/src/browser/ProvideProvider.tsx
@@ -28,13 +28,6 @@ interface Props {
 const ProviderContext = createContext<Eip1193Provider | null>(null)
 export const useProvider = () => useContext(ProviderContext)
 
-const WrappingProviderContext = createContext<WrappingProvider | null>(null)
-export const useWrappingProvider = () => {
-  const value = useContext(WrappingProviderContext)
-  if (!value) throw new Error('must be wrapped in <ProvideProvider>')
-  return value
-}
-
 const SubmitTransactionsContext = createContext<(() => Promise<string>) | null>(
   null
 )
@@ -144,13 +137,11 @@ const ProvideProvider: React.FC<Props> = ({ simulate, children }) => {
     <ProviderContext.Provider
       value={simulate ? forkProvider : wrappingProvider}
     >
-      <WrappingProviderContext.Provider value={wrappingProvider}>
-        <SubmitTransactionsContext.Provider
-          value={simulate ? submitTransactions : null}
-        >
-          {children}
-        </SubmitTransactionsContext.Provider>
-      </WrappingProviderContext.Provider>
+      <SubmitTransactionsContext.Provider
+        value={simulate ? submitTransactions : null}
+      >
+        {children}
+      </SubmitTransactionsContext.Provider>
     </ProviderContext.Provider>
   )
 }

--- a/extension/src/components/Address/index.tsx
+++ b/extension/src/components/Address/index.tsx
@@ -54,9 +54,12 @@ const Address: React.FC<Props> = ({
 
   return (
     <Box rounded className={cn(classes.container, className)}>
-      <div className={classes.address}>{displayAddress}</div>
+      <div className={classes.address}>
+        {checksumAddress ? displayAddress : 'No connection'}
+      </div>
       <Box rounded className={classes.blockieContainer}>
         {address && <Blockie address={address} className={classes.blockies} />}
+        {!address && <div className={classes.noAddress} />}
       </Box>
       {copyToClipboard && (
         <IconButton

--- a/extension/src/components/Address/style.module.css
+++ b/extension/src/components/Address/style.module.css
@@ -15,6 +15,7 @@
 .address {
   font-family: 'Roboto Mono', monospace;
   font-size: 14px;
+  white-space: nowrap;
 }
 
 .link {
@@ -25,4 +26,26 @@
   height: 100%;
   width: auto;
   aspect-ratio: 1;
+}
+
+.noAddress {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+.noAddress:after,
+.noAddress:before {
+  content: '';
+  height: calc(100% + var(--spacing-1) * 2);
+  width: 2px;
+  position: absolute;
+  top: calc(var(--spacing-1) * -1);
+  left: calc(50% - 1px);
+  background-color: var(--border-color);
+  transform: rotate(45deg);
+}
+
+.noAddress:before {
+  transform: rotate(-45deg);
 }

--- a/extension/src/components/Button/index.tsx
+++ b/extension/src/components/Button/index.tsx
@@ -3,13 +3,22 @@ import React from 'react'
 
 import classes from './style.module.css'
 
-const Button: React.FC<
-  React.DetailedHTMLProps<
+interface ButtonProps
+  extends React.DetailedHTMLProps<
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     HTMLButtonElement
-  >
-> = ({ className, ...rest }) => (
-  <button className={cn(classes.button, className)} {...rest} />
+  > {
+  secondary?: boolean
+}
+const Button: React.FC<ButtonProps> = ({
+  className,
+  secondary = false,
+  ...rest
+}) => (
+  <button
+    className={cn(classes.button, className, secondary && classes.secondary)}
+    {...rest}
+  />
 )
 
 export default Button

--- a/extension/src/components/Button/style.module.css
+++ b/extension/src/components/Button/style.module.css
@@ -33,3 +33,7 @@
   height: 16px;
   margin-right: 10px;
 }
+
+.secondary {
+  background: none;
+}

--- a/extension/src/components/ConnectionBubble/index.tsx
+++ b/extension/src/components/ConnectionBubble/index.tsx
@@ -27,12 +27,14 @@ const ConnectionBubble: React.FC<ConnectionBubbleProps> = ({
           <Box bg roundedLeft className={classes.currentConnectionContainer}>
             <Flex justifyContent="space-between" alignItems="center" gap={3}>
               <div className={classes.blockieStack}>
-                <Box rounded className={classes.blockieBox}>
-                  <Blockie
-                    address={connection.pilotAddress}
-                    className={classes.blockie}
-                  />
-                </Box>
+                {connection.pilotAddress && (
+                  <Box rounded className={classes.blockieBox}>
+                    <Blockie
+                      address={connection.pilotAddress}
+                      className={classes.blockie}
+                    />
+                  </Box>
+                )}
                 {connection.moduleAddress && (
                   <Box rounded className={classes.blockieBox}>
                     <Blockie

--- a/extension/src/components/ConnectionStack/index.tsx
+++ b/extension/src/components/ConnectionStack/index.tsx
@@ -22,18 +22,15 @@ const ConnectionStack: React.FC<Props> = ({
   className,
 }) => {
   const { avatarAddress, moduleAddress, pilotAddress, moduleType } = connection
-
   return (
     <div className={cn(classes.connectionStack, className)}>
       <Box rounded className={cn([classes.address, addressBoxClass])}>
         <Address address={pilotAddress} />
-        {pilotAddress && (
-          <div className={cn(classes.helper, helperClass)}>
-            <p>Pilot Account</p>
-          </div>
-        )}
-      </Box>
 
+        <div className={cn(classes.helper, helperClass)}>
+          <p>Pilot Account</p>
+        </div>
+      </Box>
       {moduleAddress && (
         <Box roundedRight className={cn([classes.address, addressBoxClass])}>
           <Address address={moduleAddress} />

--- a/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
@@ -46,8 +46,13 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
   const [connections, setConnections] = useConnections()
   const { connection } = useConnection(connectionId)
   const connectionsHash = useConnectionsHash()
-  const [, selectConnection] = useSelectedConnectionId()
+  const [currentlySelectedConnectionId, selectConnection] =
+    useSelectedConnectionId()
   const pushConnectionsRoute = usePushConnectionsRoute()
+
+  const currentlySelectedConnection = connections.find(
+    (c) => c.id === currentlySelectedConnectionId
+  )
 
   useEffect(() => {
     const exists = connections.some((c) => c.id === connectionId)
@@ -75,13 +80,13 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
   const { hasTransactions, clearTransactions } = useClearTransactions()
   const [getConfirmation, ConfirmationModal] = useConfirmationModal()
 
-  const confirmCanLaunch = async () => {
+  const confirmClearTransactions = async () => {
     if (!hasTransactions) {
       return true
     }
 
     const confirmation = await getConfirmation(
-      'Switching connections will empty your current transaction bundle.'
+      'Switching the piloted Safe will empty your current transaction bundle.'
     )
 
     if (!confirmation) {
@@ -112,7 +117,14 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
   }
 
   const launchConnection = async () => {
-    const confirmed = await confirmCanLaunch()
+    // we continue working with the same avatar, so don't have to clear the recorded transaction
+    const keepTransactionBundle =
+      currentlySelectedConnection &&
+      currentlySelectedConnection.avatarAddress.toLowerCase() ===
+        connection.avatarAddress.toLowerCase()
+
+    const confirmed =
+      keepTransactionBundle || (await confirmClearTransactions())
 
     if (!confirmed) {
       return

--- a/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
@@ -44,7 +44,7 @@ type ConnectionPatch = {
 
 const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
   const [connections, setConnections] = useConnections()
-  const { connection, connected, connect } = useConnection(connectionId)
+  const { connection } = useConnection(connectionId)
   const connectionsHash = useConnectionsHash()
   const [, selectConnection] = useSelectedConnectionId()
   const pushConnectionsRoute = usePushConnectionsRoute()
@@ -112,26 +112,14 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
   }
 
   const launchConnection = async () => {
-    const canLaunch = await confirmCanLaunch()
+    const confirmed = await confirmCanLaunch()
 
-    if (!canLaunch) {
+    if (!confirmed) {
       return
     }
 
-    if (connected) {
-      selectConnection(connection.id)
-      onLaunched()
-      return
-    }
-
-    if (!connected && connect) {
-      const success = await connect()
-      if (success) {
-        selectConnection(connection.id)
-        onLaunched()
-        return
-      }
-    }
+    selectConnection(connection.id)
+    onLaunched()
   }
 
   const error = useConnectionDryRun(connection)
@@ -147,7 +135,6 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
   const defaultModOption =
     pilotIsOwner || pilotIsDelegate ? NO_MODULE_OPTION : ''
 
-  const canLaunch = connected || !!connect
   const canRemove = connections.length > 1
 
   return (
@@ -164,7 +151,7 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
             <Flex gap={4} alignItems="center">
               <Button
                 className={classes.launchButton}
-                disabled={!canLaunch}
+                disabled={!connection.avatarAddress}
                 onClick={launchConnection}
               >
                 Launch

--- a/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
@@ -121,7 +121,8 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
     const keepTransactionBundle =
       currentlySelectedConnection &&
       currentlySelectedConnection.avatarAddress.toLowerCase() ===
-        connection.avatarAddress.toLowerCase()
+        connection.avatarAddress.toLowerCase() &&
+      currentlySelectedConnection.chainId == connection.chainId
 
     const confirmed =
       keepTransactionBundle || (await confirmClearTransactions())

--- a/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/Edit/index.tsx
@@ -86,7 +86,7 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
     }
 
     const confirmation = await getConfirmation(
-      'Switching the piloted Safe will empty your current transaction bundle.'
+      'Switching the Piloted Safe will empty your current transaction bundle.'
     )
 
     if (!confirmation) {
@@ -217,13 +217,20 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
               <AvatarInput
                 availableSafes={safes}
                 value={avatarAddress}
-                onChange={(address) =>
-                  updateConnection({
-                    avatarAddress: address,
-                    moduleAddress: '',
-                    moduleType: undefined,
-                  })
-                }
+                onChange={async (address) => {
+                  const keepTransactionBundle =
+                    address.toLowerCase() ===
+                    connection.avatarAddress.toLowerCase()
+                  const confirmed =
+                    keepTransactionBundle || (await confirmClearTransactions())
+                  if (confirmed) {
+                    updateConnection({
+                      avatarAddress: address,
+                      moduleAddress: '',
+                      moduleType: undefined,
+                    })
+                  }
+                }}
               />
             </Field>
             <Field label="Zodiac Mod" disabled={modules.length === 0}>

--- a/extension/src/connections/ConnectionsDrawer/List/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/List/index.tsx
@@ -48,7 +48,7 @@ const ConnectionItem: React.FC<ConnectionItemProps> = ({
     }
 
     const confirmation = await getConfirmation(
-      'Switching the piloted Safe will empty your current transaction bundle.'
+      'Switching the Piloted Safe will empty your current transaction bundle.'
     )
 
     if (!confirmation) {

--- a/extension/src/connections/ConnectionsDrawer/List/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/List/index.tsx
@@ -21,6 +21,7 @@ import { Connection, ProviderType } from '../../../types'
 import { useClearTransactions } from '../../../browser/state/transactionHooks'
 
 import classes from './style.module.css'
+import { validateAddress } from '../../../utils'
 
 interface ConnectionsListProps {
   onLaunched: () => void
@@ -41,7 +42,7 @@ const ConnectionItem: React.FC<ConnectionItemProps> = ({
   const [getConfirmation, ConfirmationModal] = useConfirmationModal()
   const { hasTransactions, clearTransactions } = useClearTransactions()
 
-  const handleCanLaunch = async () => {
+  const confirmLaunch = async () => {
     if (!hasTransactions) {
       return true
     }
@@ -60,27 +61,19 @@ const ConnectionItem: React.FC<ConnectionItemProps> = ({
   }
 
   const handleModify = () => onModify(connection.id)
+
   const handleLaunch = async () => {
-    const canLaunch = await handleCanLaunch()
+    const confirmed = await confirmLaunch()
 
-    if (!canLaunch) {
+    if (!confirmed) {
       return
     }
 
-    if (connected) {
+    if (validateAddress(connection.avatarAddress)) {
       onLaunch(connection.id)
-      return
+    } else {
+      handleModify()
     }
-
-    if (!connected && connect) {
-      const success = await connect()
-      if (success) {
-        onLaunch(connection.id)
-        return
-      }
-    }
-
-    handleModify()
   }
 
   return (

--- a/extension/src/connections/ConnectionsDrawer/List/index.tsx
+++ b/extension/src/connections/ConnectionsDrawer/List/index.tsx
@@ -67,7 +67,8 @@ const ConnectionItem: React.FC<ConnectionItemProps> = ({
     const keepTransactionBundle =
       currentlySelectedConnection &&
       currentlySelectedConnection.avatarAddress.toLowerCase() ===
-        connection.avatarAddress.toLowerCase()
+        connection.avatarAddress.toLowerCase() &&
+      currentlySelectedConnection.chainId === connection.chainId
 
     const confirmed =
       keepTransactionBundle || (await confirmClearTransactions())

--- a/extension/src/connections/useConnectionDryRun.tsx
+++ b/extension/src/connections/useConnectionDryRun.tsx
@@ -113,7 +113,7 @@ const handleRolesV2Error = (e: JsonRpcError, roleKey: string) => {
 }
 
 async function dryRun(provider: Eip1193Provider, connection: Connection) {
-  if (!validateAddress(connection.pilotAddress)) {
+  if (connection.pilotAddress && !validateAddress(connection.pilotAddress)) {
     return Promise.reject('Pilot Account: Invalid address')
   }
   if (!validateAddress(connection.moduleAddress)) {
@@ -142,8 +142,15 @@ async function dryRun(provider: Eip1193Provider, connection: Connection) {
       data: '0x00000000',
       from: connection.avatarAddress,
     },
-    connection
+    connection,
+    false
   )
+
+  // TODO enable this once we can query role members from ser
+  // if (!request.from && connection.roleId) {
+  //   // If pilotAddress is not yet determined, we will use a random member of the specified role
+  //   request.from = await getRoleMember(connection)
+  // }
 
   await provider.request({
     method: 'eth_estimateGas',

--- a/extension/src/injection.ts
+++ b/extension/src/injection.ts
@@ -21,7 +21,7 @@ console.log('injected into', document.title)
 
 // establish message bridge for location requests
 window.addEventListener('message', (ev: MessageEvent) => {
-  const { zodiacPilotHrefRequest } = ev.data
+  const { zodiacPilotHrefRequest, zodiacPilotReloadRequest } = ev.data
   if (zodiacPilotHrefRequest) {
     if (!window.top) throw new Error('Must run inside iframe')
     window.top.postMessage(
@@ -31,6 +31,10 @@ window.addEventListener('message', (ev: MessageEvent) => {
       },
       '*'
     )
+  }
+
+  if (zodiacPilotReloadRequest) {
+    window.location.reload()
   }
 })
 

--- a/extension/src/location.ts
+++ b/extension/src/location.ts
@@ -36,7 +36,8 @@ export const reloadIframe = () => {
   ) as HTMLIFrameElement | null
   const iframeWindow = iframe?.contentWindow
   if (!iframeWindow) return
-  iframeWindow.location.reload()
+
+  iframeWindow.postMessage({ zodiacPilotReloadRequest: true }, '*')
 }
 
 // The background script listens to all possible ways of location updates in our iframe and notify us via a message.

--- a/extension/src/providers/WrappingProvider.ts
+++ b/extension/src/providers/WrappingProvider.ts
@@ -15,7 +15,8 @@ const DelayInterface = ContractFactories[KnownContracts.DELAY].createInterface()
 
 export function wrapRequest(
   request: MetaTransaction | TransactionData,
-  connection: Connection
+  connection: Connection,
+  revertOnError = true
 ): TransactionData {
   if (!connection.moduleAddress) {
     throw new Error('No wrapping should be applied for direct execution')
@@ -30,7 +31,7 @@ export function wrapRequest(
         request.data || '0x00',
         ('operation' in request && request.operation) || 0,
         connection.roleId || 0,
-        true,
+        revertOnError,
       ])
       break
     case KnownContracts.ROLES_V2:
@@ -41,7 +42,7 @@ export function wrapRequest(
         ('operation' in request && request.operation) || 0,
         connection.roleId ||
           '0x0000000000000000000000000000000000000000000000000000000000000000',
-        true,
+        revertOnError,
       ])
       break
     case KnownContracts.DELAY:


### PR DESCRIPTION
We now allow launching also if we don't have a connected Pilot wallet.

There are two cases we're handling:

- The Pilot wallet was never connected before, meaning `pilotAddress` is not set
  - For now we disable role permission checks. (We could potentially enable them by querying an example role member of the specified role, but I left this for later)
  - When submitting we request to connect the pilot account, thus lazily completing the connection
- The Pilot wallet was connected in the past, so the connection remembers that `pilotAddress`
  - We simulate using this account and role permission checks will be available
  - We request to connect that account once the user tries to submit 
  
For the lazy connect on submit flow, we're taking the user to the connection Edit panel. After clicking the `Launch` button there, they can press the `Submit` button. User guidance through this flow could probably be improved. Maybe you have a quick idea, @samepant?

In a related change, recorded transaction bundles will no longer be generally cleared when switching connections or pressing a connection's `Launch` button. Instead this now only happens if the connection's `avatarAddress` changes. This means people can now seamlessly switch and modify connections as long as the impersonated account stays the same. 