### PR TITLE
chore: clear chrome mock listeners after each test

### DIFF
--- a/extension/setup-chrome-mock.ts
+++ b/extension/setup-chrome-mock.ts
@@ -1,4 +1,4 @@
-import { beforeEach, vi } from 'vitest'
+import { afterEach, beforeEach, vi } from 'vitest'
 import { chrome as chromeMock } from 'vitest-chrome'
 
 const setPanelBehavior = vi.fn()
@@ -12,4 +12,34 @@ Object.assign(chromeMock, {
 
 beforeEach(() => setPanelBehavior.mockResolvedValue(null))
 
+afterEach(() => {
+  clearAllListeners()
+})
+
 Object.assign(global, { chrome: chromeMock })
+
+const propertyDenyList = ['prototype', 'mock']
+
+const clearAllListeners = (parent = chromeMock) => {
+  Object.getOwnPropertyNames(parent).forEach((propertyName) => {
+    const property = parent[propertyName]
+
+    if (propertyDenyList.includes(propertyName)) {
+      return
+    }
+
+    const supportsInOperator =
+      typeof property !== 'number' &&
+      typeof property !== 'string' &&
+      typeof property !== 'boolean' &&
+      typeof property !== 'undefined'
+
+    if (supportsInOperator) {
+      if ('clearListeners' in property) {
+        property.clearListeners()
+      }
+
+      clearAllListeners(property)
+    }
+  })
+}

--- a/extension/src/background/sessionTracking.spec.ts
+++ b/extension/src/background/sessionTracking.spec.ts
@@ -6,17 +6,14 @@ import {
   mockActiveTab,
   startPilotSession,
 } from '@/test-utils'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { clearAllSessions, getPilotSession } from './activePilotSessions'
 import { trackRequests } from './rpcTracking'
 import { trackSessions } from './sessionTracking'
 
 describe('Session tracking', () => {
-  beforeAll(() => {
-    trackSessions(trackRequests())
-  })
-
   beforeEach(() => {
+    trackSessions(trackRequests())
     clearAllSessions()
 
     mockActiveTab()

--- a/extension/src/background/simulationTracking.spec.ts
+++ b/extension/src/background/simulationTracking.spec.ts
@@ -9,20 +9,18 @@ import {
   stopSimulation,
   updateSimulation,
 } from '@/test-utils'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { clearAllSessions } from './activePilotSessions'
 import { trackRequests } from './rpcTracking'
 import { trackSessions } from './sessionTracking'
 import { trackSimulations } from './simulationTracking'
 
 describe('Simulation tracking', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     const trackRequestsResult = trackRequests()
     trackSessions(trackRequestsResult)
     trackSimulations()
-  })
 
-  beforeEach(() => {
     clearAllSessions()
     mockActiveTab()
   })


### PR DESCRIPTION
Before, listeners were kept for the whole test suite. This can lead to false positives/negatives and makes tests harder to debug when they fail.