### PR TITLE
chore: refactor transaction remove modal on edit route

### DIFF
--- a/extension/src/components/inputs/Input.tsx
+++ b/extension/src/components/inputs/Input.tsx
@@ -1,5 +1,12 @@
-import { type ReactNode, useId } from 'react'
+import { createContext, type ReactNode, useContext, useId } from 'react'
 import { Label } from './Label'
+
+type InputContextOptions = {
+  clearLabel?: string
+  dropdownLabel?: string
+}
+
+const InputContext = createContext<InputContextOptions>({})
 
 type RenderProps = {
   inputId: string
@@ -13,7 +20,7 @@ type InputProps = {
   before?: ReactNode
   after?: ReactNode
   children: (props: RenderProps) => ReactNode
-}
+} & InputContextOptions
 
 export type ComposableInputProps = Omit<
   InputProps,
@@ -27,6 +34,8 @@ export const Input = ({
   label,
   description,
   error,
+  clearLabel,
+  dropdownLabel,
 }: InputProps) => {
   const inputId = useId()
   const descriptionId = useId()
@@ -43,15 +52,29 @@ export const Input = ({
         )}
       </div>
 
-      <div className="flex items-center rounded-md border border-zinc-300 bg-zinc-100 shadow-sm transition-all dark:border-zinc-600 dark:bg-zinc-800 dark:text-white dark:hover:border-zinc-500">
-        {before}
+      <InputContext value={{ clearLabel, dropdownLabel }}>
+        <div className="flex items-center rounded-md border border-zinc-300 bg-zinc-100 shadow-sm transition-all dark:border-zinc-600 dark:bg-zinc-800 dark:text-white dark:hover:border-zinc-500">
+          {before}
 
-        <div className="flex-1">{children({ inputId, descriptionId })}</div>
+          <div className="flex-1">{children({ inputId, descriptionId })}</div>
 
-        {after}
-      </div>
+          {after}
+        </div>
+      </InputContext>
 
       {error && <div className="text-sm font-bold text-red-600">{error}</div>}
     </div>
   )
+}
+
+export const useClearLabel = () => {
+  const { clearLabel } = useContext(InputContext)
+
+  return clearLabel
+}
+
+export const useDropdownLabel = () => {
+  const { dropdownLabel } = useContext(InputContext)
+
+  return dropdownLabel
 }

--- a/extension/src/components/inputs/Select.tsx
+++ b/extension/src/components/inputs/Select.tsx
@@ -1,8 +1,11 @@
+import { ChevronDown, X } from 'lucide-react'
 import BaseSelect, {
   type ClassNamesConfig,
+  type CommonProps,
   type GroupBase,
   type Props,
 } from 'react-select'
+import { GhostButton } from '../buttons'
 import { Input } from './Input'
 
 export const selectStyles = <
@@ -36,9 +39,33 @@ export function Select<Option = unknown, Multi extends boolean = boolean>({
           {...props}
           unstyled
           inputId={inputId}
+          components={{
+            ClearIndicator: ClearIndicator<Option, Multi>,
+            DropdownIndicator,
+          }}
           classNames={selectStyles<Option, Multi>()}
         />
       )}
     </Input>
   )
 }
+
+function ClearIndicator<Option, IsMulti extends boolean>({
+  clearValue,
+}: CommonProps<Option, IsMulti, GroupBase<Option>>) {
+  return (
+    <GhostButton iconOnly icon={X} size="small" onClick={clearValue}>
+      Clear piloted Safe
+    </GhostButton>
+  )
+}
+
+Select.ClearIndicator = ClearIndicator
+
+const DropdownIndicator = () => (
+  <GhostButton iconOnly icon={ChevronDown} size="small">
+    View available Safes
+  </GhostButton>
+)
+
+Select.DropdownIndicator = DropdownIndicator

--- a/extension/src/components/inputs/Select.tsx
+++ b/extension/src/components/inputs/Select.tsx
@@ -6,7 +6,7 @@ import BaseSelect, {
   type Props,
 } from 'react-select'
 import { GhostButton } from '../buttons'
-import { Input } from './Input'
+import { Input, useClearLabel, useDropdownLabel } from './Input'
 
 export const selectStyles = <
   Option = unknown,
@@ -55,7 +55,7 @@ function ClearIndicator<Option, IsMulti extends boolean>({
 }: CommonProps<Option, IsMulti, GroupBase<Option>>) {
   return (
     <GhostButton iconOnly icon={X} size="small" onClick={clearValue}>
-      Clear piloted Safe
+      {useClearLabel()}
     </GhostButton>
   )
 }
@@ -64,7 +64,7 @@ Select.ClearIndicator = ClearIndicator
 
 const DropdownIndicator = () => (
   <GhostButton iconOnly icon={ChevronDown} size="small">
-    View available Safes
+    {useDropdownLabel()}
   </GhostButton>
 )
 

--- a/extension/src/panel/pages/ClearTransactionsModal.tsx
+++ b/extension/src/panel/pages/ClearTransactionsModal.tsx
@@ -1,9 +1,4 @@
-import {
-  GhostButton,
-  Modal,
-  PrimaryButton,
-  useConfirmationModal,
-} from '@/components'
+import { GhostButton, Modal, PrimaryButton } from '@/components'
 import { useClearTransactions } from './useClearTransactions'
 
 type ClearTransactionsModalProps = {
@@ -45,29 +40,4 @@ export const ClearTransactionsModal = ({
       </Modal.Actions>
     </Modal>
   )
-}
-
-export const useConfirmClearTransactions = () => {
-  const { hasTransactions, clearTransactions } = useClearTransactions()
-  const [getConfirmation, ConfirmationModal] = useConfirmationModal()
-
-  const confirmClearTransactions = async () => {
-    if (!hasTransactions) {
-      return true
-    }
-
-    const confirmation = await getConfirmation(
-      'Switching the Piloted Safe will empty your current transaction bundle.',
-    )
-
-    if (!confirmation) {
-      return false
-    }
-
-    clearTransactions()
-
-    return true
-  }
-
-  return [confirmClearTransactions, ConfirmationModal] as const
 }

--- a/extension/src/panel/pages/routes/edit.$routeId/AvatarInput.tsx
+++ b/extension/src/panel/pages/routes/edit.$routeId/AvatarInput.tsx
@@ -27,7 +27,11 @@ export const AvatarInput = ({
   return (
     <>
       {availableSafes.length > 0 || checksumAvatarAddress ? (
-        <Input label="Piloted Safe">
+        <Input
+          label="Piloted Safe"
+          clearLabel="Clear piloted Safe"
+          dropdownLabel="View all available Safes"
+        >
           {({ inputId }) => (
             <CreatableSelect
               unstyled

--- a/extension/src/panel/pages/routes/edit.$routeId/AvatarInput.tsx
+++ b/extension/src/panel/pages/routes/edit.$routeId/AvatarInput.tsx
@@ -1,7 +1,15 @@
-import { Blockie, Input, selectStyles, TextInput } from '@/components'
+import {
+  Blockie,
+  GhostButton,
+  Input,
+  selectStyles,
+  TextInput,
+} from '@/components'
 import { validateAddress } from '@/utils'
 import { getAddress } from 'ethers'
+import { ChevronDown, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import type { CommonProps, GroupBase } from 'react-select'
 import CreatableSelect from 'react-select/creatable'
 import type { Option } from './ModSelect'
 
@@ -34,6 +42,7 @@ export const AvatarInput = ({
               inputId={inputId}
               blurInputOnSelect
               isClearable
+              components={{ ClearIndicator, DropdownIndicator }}
               formatOptionLabel={SafeOptionLabel}
               placeholder="Paste an address or select from the list"
               classNames={selectStyles<{ value: string; label: string }>()}
@@ -97,3 +106,17 @@ const SafeOptionLabel = (option: Option) => {
     </div>
   )
 }
+
+const ClearIndicator = ({
+  clearValue,
+}: CommonProps<Option, false, GroupBase<Option>>) => (
+  <GhostButton iconOnly icon={X} size="small" onClick={clearValue}>
+    Clear piloted Safe
+  </GhostButton>
+)
+
+const DropdownIndicator = () => (
+  <GhostButton iconOnly icon={ChevronDown} size="small">
+    View available Safes
+  </GhostButton>
+)

--- a/extension/src/panel/pages/routes/edit.$routeId/AvatarInput.tsx
+++ b/extension/src/panel/pages/routes/edit.$routeId/AvatarInput.tsx
@@ -1,15 +1,7 @@
-import {
-  Blockie,
-  GhostButton,
-  Input,
-  selectStyles,
-  TextInput,
-} from '@/components'
+import { Blockie, Input, Select, selectStyles, TextInput } from '@/components'
 import { validateAddress } from '@/utils'
 import { getAddress } from 'ethers'
-import { ChevronDown, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import type { CommonProps, GroupBase } from 'react-select'
 import CreatableSelect from 'react-select/creatable'
 import type { Option } from './ModSelect'
 
@@ -42,7 +34,10 @@ export const AvatarInput = ({
               inputId={inputId}
               blurInputOnSelect
               isClearable
-              components={{ ClearIndicator, DropdownIndicator }}
+              components={{
+                ClearIndicator: Select.ClearIndicator<Option, false>,
+                DropdownIndicator: Select.DropdownIndicator,
+              }}
               formatOptionLabel={SafeOptionLabel}
               placeholder="Paste an address or select from the list"
               classNames={selectStyles<{ value: string; label: string }>()}
@@ -106,17 +101,3 @@ const SafeOptionLabel = (option: Option) => {
     </div>
   )
 }
-
-const ClearIndicator = ({
-  clearValue,
-}: CommonProps<Option, false, GroupBase<Option>>) => (
-  <GhostButton iconOnly icon={X} size="small" onClick={clearValue}>
-    Clear piloted Safe
-  </GhostButton>
-)
-
-const DropdownIndicator = () => (
-  <GhostButton iconOnly icon={ChevronDown} size="small">
-    View available Safes
-  </GhostButton>
-)

--- a/extension/src/panel/pages/routes/edit.$routeId/EditRoute.tsx
+++ b/extension/src/panel/pages/routes/edit.$routeId/EditRoute.tsx
@@ -54,11 +54,11 @@ import {
   splitPrefixedAddress,
   type ChainId,
 } from 'ser-kit'
+import { ClearTransactionsModal } from '../../ClearTransactionsModal'
 import {
   asLegacyConnection,
   fromLegacyConnection,
 } from '../../legacyConnectionMigrations'
-import { ClearTransactionsModal } from '../../useConfirmClearTransaction'
 import { AvatarInput } from './AvatarInput'
 import { ChainSelect } from './ChainSelect'
 import { getRouteId } from './getRouteId'

--- a/extension/src/panel/pages/routes/edit.$routeId/EditRoute.tsx
+++ b/extension/src/panel/pages/routes/edit.$routeId/EditRoute.tsx
@@ -20,6 +20,7 @@ import {
   saveRoute,
 } from '@/execution-routes'
 import { useDisconnectWalletConnectIfNeeded } from '@/providers'
+import { useTransactions } from '@/state'
 import type { HexAddress, LegacyConnection } from '@/types'
 import {
   decodeRoleKey,
@@ -57,7 +58,7 @@ import {
   asLegacyConnection,
   fromLegacyConnection,
 } from '../../legacyConnectionMigrations'
-import { useConfirmClearTransactions } from '../../useConfirmClearTransaction'
+import { ClearTransactionsModal } from '../../useConfirmClearTransaction'
 import { AvatarInput } from './AvatarInput'
 import { ChainSelect } from './ChainSelect'
 import { getRouteId } from './getRouteId'
@@ -173,6 +174,9 @@ export const EditRoute = () => {
   const { initialRouteState, currentExecutionRoute, zodiacModules } =
     useLoaderData<typeof loader>()
   const [currentRouteState, setCurrentRouteState] = useState(initialRouteState)
+  const [confirmClearTransactions, setConfirmClearTransactions] =
+    useState(false)
+  const transactions = useTransactions()
 
   const legacyConnection = asLegacyConnection(currentRouteState)
   const { label, avatarAddress, pilotAddress, roleId, chainId, moduleAddress } =
@@ -184,9 +188,6 @@ export const EditRoute = () => {
     chainId,
     avatarAddress as HexAddress,
   )
-
-  const [confirmClearTransactions, ConfirmationModal] =
-    useConfirmClearTransactions()
 
   const updateRoute = (patch: ConnectionPatch) => {
     console.debug('updateRoute', patch)
@@ -278,19 +279,12 @@ export const EditRoute = () => {
             <AvatarInput
               availableSafes={safes}
               value={avatarAddress === ZeroAddress ? '' : avatarAddress || ''}
-              onChange={async (address) => {
-                const keepTransactionBundle =
-                  address.toLowerCase() === avatarAddress.toLowerCase()
-                const confirmed =
-                  keepTransactionBundle || (await confirmClearTransactions())
-
-                if (confirmed) {
-                  updateRoute({
-                    avatarAddress: address || undefined,
-                    moduleAddress: '',
-                    moduleType: undefined,
-                  })
-                }
+              onChange={(address) => {
+                updateRoute({
+                  avatarAddress: address || undefined,
+                  moduleAddress: '',
+                  moduleType: undefined,
+                })
               }}
             />
 
@@ -428,16 +422,17 @@ export const EditRoute = () => {
                 // we continue working with the same avatar, so don't have to clear the recorded transaction
                 const keepTransactionBundle =
                   currentExecutionRoute == null ||
-                  currentExecutionRoute.avatar === currentRouteState.avatar
+                  currentExecutionRoute.avatar.toLowerCase() ===
+                    currentRouteState.avatar.toLowerCase() ||
+                  transactions.length === 0
 
-                const confirmed =
-                  keepTransactionBundle || (await confirmClearTransactions())
+                if (keepTransactionBundle) {
+                  submit(formRef.current, { method: 'post' })
 
-                if (!confirmed) {
                   return
                 }
 
-                submit(formRef.current, { method: 'post' })
+                setConfirmClearTransactions(true)
               }}
             >
               Save & Launch
@@ -446,7 +441,11 @@ export const EditRoute = () => {
         </Page.Footer>
       </Page>
 
-      <ConfirmationModal />
+      <ClearTransactionsModal
+        open={confirmClearTransactions}
+        onClose={() => setConfirmClearTransactions(false)}
+        onConfirm={() => submit(formRef.current, { method: 'post' })}
+      />
     </>
   )
 }

--- a/extension/src/panel/pages/routes/list/ListRoutes.spec.ts
+++ b/extension/src/panel/pages/routes/list/ListRoutes.spec.ts
@@ -117,7 +117,7 @@ describe('List routes', () => {
       ).toBeInTheDocument()
     })
 
-    it('warns about clearing transactions when the avatars differ', async () => {
+    it('does not warn about clearing transactions when the avatars stay the same', async () => {
       const selectedRoute = createMockRoute({
         id: 'firstRoute',
         label: 'First route',

--- a/extension/src/panel/pages/routes/list/Route.tsx
+++ b/extension/src/panel/pages/routes/list/Route.tsx
@@ -11,9 +11,9 @@ import { formatDistanceToNow } from 'date-fns'
 import { Cable, PlugZap, Unplug } from 'lucide-react'
 import { useRef, useState } from 'react'
 import { useSubmit } from 'react-router'
+import { ClearTransactionsModal } from '../../ClearTransactionsModal'
 import { ConnectionStack } from '../../ConnectionStack'
 import { asLegacyConnection } from '../../legacyConnectionMigrations'
-import { ClearTransactionsModal } from '../../useConfirmClearTransaction'
 import { Intent } from './intents'
 
 interface RouteProps {


### PR DESCRIPTION
Relates to #389 

Replace the old transaction modal mechanism with a new one. Also, we now use our own components for select controls and they are more accessible.