### PR TITLE
fix big int serialization

### DIFF
--- a/extension/src/components/CopyToClipboard.spec.tsx
+++ b/extension/src/components/CopyToClipboard.spec.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { CopyToClipboard } from './CopyToClipboard'
+
+describe('Copy to clipboard', () => {
+  it('is possible to copy data with BigInt values', async () => {
+    const clipboardSpy = vi.spyOn(navigator.clipboard, 'writeText')
+
+    render(<CopyToClipboard data={{ value: 1n }}>Copy</CopyToClipboard>)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy' }))
+
+    expect(clipboardSpy).toHaveBeenCalledWith(
+      JSON.stringify({ value: '1' }, undefined, 2),
+    )
+  })
+})

--- a/extension/src/components/CopyToClipboard.tsx
+++ b/extension/src/components/CopyToClipboard.tsx
@@ -13,7 +13,19 @@ export const CopyToClipboard = ({ data, ...props }: CopyToClipboardProps) => (
     {...props}
     icon={Copy}
     onClick={() => {
-      navigator.clipboard.writeText(JSON.stringify(data, undefined, 2))
+      navigator.clipboard.writeText(
+        JSON.stringify(
+          data,
+          (_, value) => {
+            if (typeof value === 'bigint') {
+              return value.toString()
+            }
+
+            return value
+          },
+          2,
+        ),
+      )
 
       infoToast({
         title: 'Copied!',


### PR DESCRIPTION
Fixes #417 

`BigInt` isn't natively handled by JSON serialization, so we must do it manually.