### PR TITLE
fix(pilot-app, extension): submit connect wallet button not working

### DIFF
--- a/deployables/extension/src/panel/execution-routes/getRoutes.ts
+++ b/deployables/extension/src/panel/execution-routes/getRoutes.ts
@@ -1,5 +1,5 @@
 import type { ExecutionRoute } from '@/types'
-import { Chain, ZERO_ADDRESS } from '@zodiac/chains'
+import { ZERO_ADDRESS } from '@zodiac/chains'
 import { createEoaStartingPoint } from '@zodiac/modules'
 import { getStorageEntries } from '../utils'
 
@@ -12,7 +12,6 @@ export const getRoutes = async (): Promise<ExecutionRoute[]> => {
           ...route,
           waypoints: [
             createEoaStartingPoint({
-              chainId: Chain.ETH,
               address: ZERO_ADDRESS,
             }),
           ],

--- a/deployables/extension/src/panel/pages/$activeRouteId/transactions/Submit.tsx
+++ b/deployables/extension/src/panel/pages/$activeRouteId/transactions/Submit.tsx
@@ -1,3 +1,4 @@
+import { useCompanionAppUrl } from '@/companion'
 import { useExecutionRoute, useRouteConnect } from '@/execution-routes'
 import { usePilotIsReady } from '@/port-handling'
 import { getReadOnlyProvider } from '@/providers'
@@ -35,6 +36,8 @@ export const Submit = () => {
   const transactions = useTransactions()
   const submitTransactions = useSubmitTransactions()
   const [signaturePending, setSignaturePending] = useState(false)
+
+  const companionAppUrl = useCompanionAppUrl()
 
   const submit = async () => {
     if (!connected) {
@@ -162,7 +165,11 @@ export const Submit = () => {
           Submit
         </PrimaryButton>
       ) : (
-        <PrimaryLinkButton fluid to={`/routes/edit/${route.id}`}>
+        <PrimaryLinkButton
+          openInNewWindow
+          fluid
+          to={`${companionAppUrl}/edit-route/${btoa(JSON.stringify(route))}`}
+        >
           Connect wallet to submit
         </PrimaryLinkButton>
       )}

--- a/packages/modules/src/createBlankRoute.spec.ts
+++ b/packages/modules/src/createBlankRoute.spec.ts
@@ -40,7 +40,7 @@ describe('createBlankRoute', () => {
       expect(startingPoint.account).toHaveProperty('address', ZERO_ADDRESS)
       expect(startingPoint.account).toHaveProperty(
         'prefixedAddress',
-        formatPrefixedAddress(Chain.ETH, ZERO_ADDRESS),
+        formatPrefixedAddress(undefined, ZERO_ADDRESS),
       )
     })
   })

--- a/packages/modules/src/createBlankRoute.ts
+++ b/packages/modules/src/createBlankRoute.ts
@@ -8,7 +8,5 @@ export const createBlankRoute = (): ExecutionRoute => ({
   id: nanoid(),
   avatar: formatPrefixedAddress(Chain.ETH, ZERO_ADDRESS),
   label: '',
-  waypoints: [
-    createEoaStartingPoint({ chainId: Chain.ETH, address: ZERO_ADDRESS }),
-  ],
+  waypoints: [createEoaStartingPoint({ address: ZERO_ADDRESS })],
 })

--- a/packages/modules/src/createEoaAccount.ts
+++ b/packages/modules/src/createEoaAccount.ts
@@ -1,23 +1,16 @@
 import type { HexAddress } from '@zodiac/schema'
-import {
-  AccountType,
-  formatPrefixedAddress,
-  type Account,
-  type ChainId,
-} from 'ser-kit'
+import { AccountType, formatPrefixedAddress, type Account } from 'ser-kit'
 
 type EOA = Extract<Account, { type: AccountType.EOA }>
 
 export type CreateEoaAccountOptions = {
-  chainId: ChainId
   address: HexAddress
 }
 
 export const createEoaAccount = ({
-  chainId,
   address,
 }: CreateEoaAccountOptions): EOA => ({
   type: AccountType.EOA,
   address,
-  prefixedAddress: formatPrefixedAddress(chainId, address),
+  prefixedAddress: formatPrefixedAddress(undefined, address),
 })

--- a/packages/modules/src/updateChainId.spec.ts
+++ b/packages/modules/src/updateChainId.spec.ts
@@ -10,7 +10,11 @@ import {
   createMockWaypoints,
   randomAddress,
 } from '@zodiac/test-utils'
-import { AccountType, formatPrefixedAddress } from 'ser-kit'
+import {
+  AccountType,
+  formatPrefixedAddress,
+  splitPrefixedAddress,
+} from 'ser-kit'
 import { describe, expect, it } from 'vitest'
 import { getStartingWaypoint } from './getStartingWaypoint'
 import { getWaypoints } from './getWaypoints'
@@ -53,12 +57,10 @@ describe('updateChainId', () => {
 
   describe('Waypoints', () => {
     describe('Starting point', () => {
-      it('updates the chain of the starting point prefixed address', () => {
+      it('does not update the starting waypoint of EOA accounts', () => {
         const route = createMockExecutionRoute({
           waypoints: createMockWaypoints({
-            start: createMockStartingWaypoint(
-              createMockEoaAccount({ chainId: Chain.ETH }),
-            ),
+            start: createMockStartingWaypoint(createMockEoaAccount()),
           }),
         })
 
@@ -66,9 +68,11 @@ describe('updateChainId', () => {
 
         const startingPoint = getStartingWaypoint(updatedRoute.waypoints)
 
-        expect(getChainId(startingPoint.account.prefixedAddress)).toEqual(
-          Chain.GNO,
+        const [chainId] = splitPrefixedAddress(
+          startingPoint.account.prefixedAddress,
         )
+
+        expect(chainId).not.toBeDefined()
       })
 
       it('updates the chain property of SAFE starting points', () => {

--- a/packages/modules/src/updatePilotAddress.spec.ts
+++ b/packages/modules/src/updatePilotAddress.spec.ts
@@ -1,4 +1,4 @@
-import { Chain, getChainId } from '@zodiac/chains'
+import { Chain } from '@zodiac/chains'
 import {
   createMockDelayWaypoint,
   createMockEnabledConnection,
@@ -29,10 +29,7 @@ describe('updatePilotAddress', () => {
     expect(startingPoint.account).toHaveProperty('address', newAddress)
     expect(startingPoint.account).toHaveProperty(
       'prefixedAddress',
-      formatPrefixedAddress(
-        getChainId(startingPoint.account.prefixedAddress),
-        newAddress,
-      ),
+      formatPrefixedAddress(undefined, newAddress),
     )
   })
 

--- a/packages/modules/src/updateProviderType.spec.ts
+++ b/packages/modules/src/updateProviderType.spec.ts
@@ -9,8 +9,9 @@ import {
   createMockStartingWaypoint,
   createMockWaypoints,
   randomAddress,
+  randomPrefixedAddress,
 } from '@zodiac/test-utils'
-import { AccountType } from 'ser-kit'
+import { AccountType, splitPrefixedAddress } from 'ser-kit'
 import { describe, expect, it } from 'vitest'
 import { getStartingWaypoint } from './getStartingWaypoint'
 import { getWaypoints } from './getWaypoints'
@@ -65,7 +66,7 @@ describe('updateProviderType', () => {
       expect(startingPoint.account).toHaveProperty('address', address)
     })
 
-    it('keeps the chain of the current starting point', () => {
+    it('switches the starting point to an EOA without chain', () => {
       const route = createMockExecutionRoute({
         waypoints: createMockWaypoints({
           start: createMockStartingWaypoint(
@@ -81,9 +82,11 @@ describe('updateProviderType', () => {
 
       const startingPoint = getStartingWaypoint(updatedRoute.waypoints)
 
-      expect(getChainId(startingPoint.account.prefixedAddress)).toEqual(
-        Chain.GNO,
+      const [chainId] = splitPrefixedAddress(
+        startingPoint.account.prefixedAddress,
       )
+
+      expect(chainId).not.toBeDefined()
     })
 
     it('keeps the other waypoints untouched', () => {
@@ -129,10 +132,7 @@ describe('updateProviderType', () => {
         }),
       })
 
-      const updatedRoute = updateProviderType(
-        route,
-        ProviderType.InjectedWallet,
-      )
+      const updatedRoute = updateProviderType(route, ProviderType.WalletConnect)
 
       const startingPoint = getStartingWaypoint(updatedRoute.waypoints)
 
@@ -141,17 +141,13 @@ describe('updateProviderType', () => {
 
     it('keeps the chain of the current starting point', () => {
       const route = createMockExecutionRoute({
+        avatar: randomPrefixedAddress({ chainId: Chain.GNO }),
         waypoints: createMockWaypoints({
-          start: createMockStartingWaypoint(
-            createMockEoaAccount({ chainId: Chain.GNO }),
-          ),
+          start: createMockStartingWaypoint(createMockEoaAccount()),
         }),
       })
 
-      const updatedRoute = updateProviderType(
-        route,
-        ProviderType.InjectedWallet,
-      )
+      const updatedRoute = updateProviderType(route, ProviderType.WalletConnect)
 
       const startingPoint = getStartingWaypoint(updatedRoute.waypoints)
 

--- a/packages/modules/src/updateProviderType.ts
+++ b/packages/modules/src/updateProviderType.ts
@@ -10,10 +10,9 @@ export const updateProviderType = (
   providerType: ProviderType,
 ): ExecutionRoute => {
   const {
-    account: { address, prefixedAddress },
+    account: { address },
   } = getStartingWaypoint(route.waypoints)
   const waypoints = getWaypoints(route)
-  const chainId = getChainId(prefixedAddress)
 
   switch (providerType) {
     case ProviderType.InjectedWallet: {
@@ -22,7 +21,6 @@ export const updateProviderType = (
         providerType: ProviderType.InjectedWallet,
         waypoints: [
           createEoaWaypoint({
-            chainId,
             address,
           }),
           ...waypoints,
@@ -31,6 +29,8 @@ export const updateProviderType = (
     }
 
     case ProviderType.WalletConnect: {
+      const chainId = getChainId(route.avatar)
+
       return {
         ...route,
         providerType: ProviderType.WalletConnect,

--- a/packages/test-utils/src/creators/createMockEoaAccount.ts
+++ b/packages/test-utils/src/creators/createMockEoaAccount.ts
@@ -1,24 +1,17 @@
-import { Chain, ZERO_ADDRESS } from '@zodiac/chains'
+import { ZERO_ADDRESS } from '@zodiac/chains'
 import type { HexAddress } from '@zodiac/schema'
-import {
-  AccountType,
-  formatPrefixedAddress,
-  type Account,
-  type ChainId,
-} from 'ser-kit'
+import { AccountType, formatPrefixedAddress, type Account } from 'ser-kit'
 
 type Eoa = Extract<Account, { type: AccountType.EOA }>
 
 type CreateMockEoaAccountOptions = {
-  chainId?: ChainId
   address?: HexAddress
 }
 
 export const createMockEoaAccount = ({
   address = ZERO_ADDRESS,
-  chainId = Chain.ETH,
 }: CreateMockEoaAccountOptions = {}): Eoa => ({
   type: AccountType.EOA,
   address,
-  prefixedAddress: formatPrefixedAddress(chainId, address),
+  prefixedAddress: formatPrefixedAddress(undefined, address),
 })


### PR DESCRIPTION
Part of #469 

- fixes the "Connect wallet to submit" button behaviour
- also fixes an issue where EOA accounts got a chain into their prefixed address