### PR TITLE
chore: timeout rpc tracking and track errors

### DIFF
--- a/deployables/extension/src/background/rpcTracking.ts
+++ b/deployables/extension/src/background/rpcTracking.ts
@@ -142,6 +142,7 @@ const detectNetworkOfRpcUrl = async (
       url,
       timeout(
         sendMessageToTab(tabId, { type: RpcMessageType.PROBE_CHAIN_ID, url }),
+        `Could not probe chain ID for url "${url}".`,
       ),
     )
   }
@@ -185,8 +186,10 @@ const trackRpcUrl = (
   }
 }
 
-const timeout = <T>(promise: Promise<T>) =>
+const timeout = <T>(promise: Promise<T>, errorMessage: string) =>
   Promise.race([
     promise,
-    new Promise<T>((_, reject) => setTimeout(() => reject(), 10_000)),
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(errorMessage), 10_000),
+    ),
   ])

--- a/deployables/extension/src/background/rpcTracking.ts
+++ b/deployables/extension/src/background/rpcTracking.ts
@@ -1,3 +1,4 @@
+import { sentry } from '@/sentry'
 import { sendMessageToTab } from '@/utils'
 import { RpcMessageType } from '@zodiac/messages'
 import type { ChainId } from 'ser-kit'
@@ -41,11 +42,13 @@ export const trackRequests = (): TrackRequestsResult => {
 
   chrome.webRequest.onBeforeRequest.addListener(
     (details) => {
-      trackRequest(state, details).then(({ newEndpoint }) => {
-        if (newEndpoint) {
-          onNewRpcEndpointDetected.callListeners()
-        }
-      })
+      trackRequest(state, details)
+        .then(({ newEndpoint }) => {
+          if (newEndpoint) {
+            onNewRpcEndpointDetected.callListeners()
+          }
+        })
+        .catch((error) => sentry.captureException(error))
     },
     {
       urls: ['<all_urls>'],
@@ -137,7 +140,9 @@ const detectNetworkOfRpcUrl = async (
   if (!chainIdPromiseByRpcUrl.has(url)) {
     chainIdPromiseByRpcUrl.set(
       url,
-      sendMessageToTab(tabId, { type: RpcMessageType.PROBE_CHAIN_ID, url }),
+      timeout(
+        sendMessageToTab(tabId, { type: RpcMessageType.PROBE_CHAIN_ID, url }),
+      ),
     )
   }
 
@@ -179,3 +184,9 @@ const trackRpcUrl = (
     urls.add(url)
   }
 }
+
+const timeout = <T>(promise: Promise<T>) =>
+  Promise.race([
+    promise,
+    new Promise<T>((_, reject) => setTimeout(() => reject(), 10_000)),
+  ])


### PR DESCRIPTION
Part of #582 

RPC tracking could get stuck when a tab would not respond. Now, each tab has 10 seconds to respond. After that the requests times out and can be tried again.