### PR TITLE
fix(extension): make it possible to connect to etherscan

### DIFF
--- a/deployables/extension/src/inject/injectedScript/main.ts
+++ b/deployables/extension/src/inject/injectedScript/main.ts
@@ -4,6 +4,14 @@ import { announceEip6963Provider } from './announceProvider'
 import { ensureInjectedProvider } from './ensureInjectedProvider'
 import { maskMetaMaskAnnouncement } from './maskMetaMaskAnnouncement'
 
+/**
+ * Some websites check for providers not based on their id
+ * but on their name. For each website in this list
+ * we'll use the native provider name instead of Zodiac Pilot
+ * when we announce the provider.
+ */
+const websitesWhereZodiacNameShouldBeAvoided = ['https://etherscan.io']
+
 const enableInjectedProvider = () => {
   // This script might be injected multiple times, so we need to check if the provider is already set.
   // This should also handle the case where the extension is installed multiple times (e.g. when loading unpacked extensions).
@@ -11,7 +19,11 @@ const enableInjectedProvider = () => {
   const { provider, initial } = ensureInjectedProvider()
 
   if (initial) {
-    maskMetaMaskAnnouncement(provider)
+    maskMetaMaskAnnouncement(provider, {
+      overrideName: !websitesWhereZodiacNameShouldBeAvoided.some((url) =>
+        window.location.href.startsWith(url),
+      ),
+    })
 
     window.addEventListener('eip6963:requestProvider', (event) => {
       announceEip6963Provider(provider)

--- a/deployables/extension/src/inject/injectedScript/maskMetaMaskAnnouncement.ts
+++ b/deployables/extension/src/inject/injectedScript/maskMetaMaskAnnouncement.ts
@@ -1,6 +1,13 @@
 import type { InjectedProvider } from './InjectedProvider'
 
-export const maskMetaMaskAnnouncement = (provider: InjectedProvider) => {
+type MetaMaskMaskOptions = {
+  overrideName: boolean
+}
+
+export const maskMetaMaskAnnouncement = (
+  provider: InjectedProvider,
+  { overrideName }: MetaMaskMaskOptions,
+) => {
   // override EIP-6963 provider announcement for MetaMask while Pilot is connected
   // (this gives us an extra chance to connect to apps that only listen to MetaMask)
   window.addEventListener('eip6963:announceProvider', (event) => {
@@ -17,7 +24,9 @@ export const maskMetaMaskAnnouncement = (provider: InjectedProvider) => {
           detail: Object.freeze({
             info: {
               ...ev.detail.info,
-              name: 'Zodiac Pilot',
+
+              ...(overrideName ? { name: 'Zodiac Pilot' } : {}),
+
               icon: '//pilot.gnosisguild.org/zodiac48.png',
             },
             provider,


### PR DESCRIPTION
Part of #484 

This PR partially resolves the issue. At least it is now possible to connect to etherscan.io **at all**. What is still not working properly is connecting to etherscan when the MetaMask extension is **also** enabled. This fix **only** works if the extension is disabled.