### PR TITLE
fix(extension): register listeners on document start

### DIFF
--- a/deployables/extension/esbuild.mjs
+++ b/deployables/extension/esbuild.mjs
@@ -26,6 +26,7 @@ esbuild
 
       // COMPANION APP TO EDIT ROUTES
       './src/companion/contentScripts/main.ts',
+      './src/companion/contentScripts/fork-support.ts',
       './src/companion/injectedScripts/main.ts',
 
       // SIDEPANEL APP

--- a/deployables/extension/src/companion/contentScripts/fork-support.spec.ts
+++ b/deployables/extension/src/companion/contentScripts/fork-support.spec.ts
@@ -1,0 +1,18 @@
+import { CompanionAppMessageType } from '@zodiac/messages'
+import { randomUUID } from 'crypto'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('Fork info', () => {
+  const importModule = () =>
+    vi.importActual<typeof import('./fork-support')>(
+      `./fork-support?bust=${randomUUID()}`,
+    )
+
+  it('requests fork info directly on script load', async () => {
+    await importModule()
+
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: CompanionAppMessageType.REQUEST_FORK_INFO,
+    })
+  })
+})

--- a/deployables/extension/src/companion/contentScripts/fork-support.ts
+++ b/deployables/extension/src/companion/contentScripts/fork-support.ts
@@ -1,0 +1,8 @@
+import {
+  CompanionAppMessageType,
+  type CompanionAppMessage,
+} from '@zodiac/messages'
+
+chrome.runtime.sendMessage<CompanionAppMessage>({
+  type: CompanionAppMessageType.REQUEST_FORK_INFO,
+})

--- a/deployables/extension/src/companion/contentScripts/main.spec.ts
+++ b/deployables/extension/src/companion/contentScripts/main.spec.ts
@@ -145,14 +145,6 @@ describe('Companion App Content Script', () => {
   })
 
   describe('Fork info', () => {
-    it('requests fork info directly on script load', async () => {
-      await importModule()
-
-      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
-        type: CompanionAppMessageType.REQUEST_FORK_INFO,
-      })
-    })
-
     it('requests for info when pilot connects', async () => {
       await importModule()
 
@@ -163,7 +155,7 @@ describe('Companion App Content Script', () => {
         vi.fn(),
       )
 
-      expect(chrome.runtime.sendMessage).toHaveBeenNthCalledWith(2, {
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
         type: CompanionAppMessageType.REQUEST_FORK_INFO,
       })
     })

--- a/deployables/extension/src/companion/contentScripts/main.ts
+++ b/deployables/extension/src/companion/contentScripts/main.ts
@@ -71,8 +71,4 @@ chrome.runtime.onMessage.addListener(
   },
 )
 
-chrome.runtime.sendMessage<CompanionAppMessage>({
-  type: CompanionAppMessageType.REQUEST_FORK_INFO,
-})
-
 injectScript('./build/companion/injectedScripts/main.js')

--- a/deployables/extension/src/manifest.template.json
+++ b/deployables/extension/src/manifest.template.json
@@ -34,9 +34,15 @@
   "content_scripts": [
     {
       "matches": ["<COMPANION_APP_URL>/*"],
-      "run_at": "document_idle",
+      "run_at": "document_start",
       "all_frames": true,
       "js": ["build/companion/contentScripts/main.js"]
+    },
+    {
+      "matches": ["<COMPANION_APP_URL>/*"],
+      "run_at": "document_idle",
+      "all_frames": true,
+      "js": ["build/companion/contentScripts/fork-support.js"]
     },
     {
       "matches": ["<all_urls>"],


### PR DESCRIPTION
This PR splits the content script for the companion app. All listeners are registered on `document_start`, and only the message to guarantee an up-to-date fork is run at the end.