### PR TITLE
chore: remove safe init hacks

### DIFF
--- a/deployables/app/app/routes/edit/list-routes.spec.ts
+++ b/deployables/app/app/routes/edit/list-routes.spec.ts
@@ -14,7 +14,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetAvailableChains = vi.mocked(getAvailableChains)
 
-describe('List Routes', () => {
+describe.sequential('List Routes', () => {
   beforeEach(() => {
     mockGetAvailableChains.mockResolvedValue([])
   })

--- a/packages/safe/package.json
+++ b/packages/safe/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "@epic-web/invariant": "1.0.0",
     "@safe-global/api-kit": "3.0.0",
     "@safe-global/protocol-kit": "6.0.0",
     "@zodiac/chains": "workspace:*"

--- a/packages/safe/src/kits.ts
+++ b/packages/safe/src/kits.ts
@@ -1,5 +1,6 @@
+import { invariant } from '@epic-web/invariant'
 import SafeApiKit from '@safe-global/api-kit'
-import Safe from '@safe-global/protocol-kit'
+import SafeProtocolKit from '@safe-global/protocol-kit'
 import { Chain, RPC, type ChainId } from '@zodiac/chains'
 
 export const TX_SERVICE_URL: Record<ChainId, string | undefined> = {
@@ -19,15 +20,8 @@ export const TX_SERVICE_URL: Record<ChainId, string | undefined> = {
 
 export const initSafeApiKit = (chainId: ChainId): SafeApiKit => {
   const txServiceUrl = TX_SERVICE_URL[chainId as ChainId]
-  if (!txServiceUrl) {
-    throw new Error(`service not available for chain #${chainId}`)
-  }
 
-  // @ts-expect-error SafeApiKit is only available as a CJS module. That doesn't play super nice with us being ESM.
-  if (SafeApiKit.default) {
-    // @ts-expect-error See above
-    return new SafeApiKit.default({ txServiceUrl, chainId: BigInt(chainId) })
-  }
+  invariant(txServiceUrl != null, `service not available for chain #${chainId}`)
 
   return new SafeApiKit({ txServiceUrl, chainId: BigInt(chainId) })
 }
@@ -35,20 +29,9 @@ export const initSafeApiKit = (chainId: ChainId): SafeApiKit => {
 export const initSafeProtocolKit = (
   chainId: ChainId,
   safeAddress: string,
-): Promise<Safe> => {
-  // @ts-expect-error protocol-kit is only available as a CJS module. That doesn't play super nice with us being ESM.
-  if (Safe.default) {
-    // @ts-expect-error protocol-kit is only available as a CJS module. That doesn't play super nice with us being ESM.
-    return Safe.default.init({
-      // we must pass the RPC endpoint as a string. If we pass an EIP1193 provider, Safe will send eth_requestAccounts calls (which will fail)
-      provider: RPC[chainId],
-      safeAddress,
-    })
-  }
-
-  return Safe.init({
+): Promise<SafeProtocolKit> =>
+  SafeProtocolKit.init({
     // we must pass the RPC endpoint as a string. If we pass an EIP1193 provider, Safe will send eth_requestAccounts calls (which will fail)
     provider: RPC[chainId],
     safeAddress,
   })
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,9 @@ importers:
 
   packages/safe:
     dependencies:
+      '@epic-web/invariant':
+        specifier: 1.0.0
+        version: 1.0.0
       '@safe-global/api-kit':
         specifier: 3.0.0
         version: 3.0.0(typescript@5.8.2)(zod@3.24.2)


### PR DESCRIPTION
After Safe has finally released their packages' ESM versions, we can eliminate some hacks.