### PR TITLE
fix(pilot-app): increase vnet transactions page size

### DIFF
--- a/deployables/app/app/simulation/server/api.ts
+++ b/deployables/app/app/simulation/server/api.ts
@@ -3,14 +3,14 @@ import type { z, ZodTypeAny } from 'zod'
 
 type ApiOptions<Schema extends ZodTypeAny> = {
   schema: Schema
-  data?: Record<string, string | number | boolean | string[] | number[]>
+  searchParams?: Record<string, string | number | boolean | string[] | number[]>
   body?: Record<string, unknown>
   method?: 'GET' | 'POST'
 }
 
 export const api = async <Schema extends ZodTypeAny>(
   endpoint: `/${string}`,
-  { schema, data = {}, method = 'GET', body }: ApiOptions<Schema>,
+  { schema, searchParams = {}, method = 'GET', body }: ApiOptions<Schema>,
 ) => {
   const { TENDERLY_ACCESS_KEY, TENDERLY_PROJECT, TENDERLY_USER } =
     getTenderlyCredentials()
@@ -27,7 +27,7 @@ export const api = async <Schema extends ZodTypeAny>(
     },
   }
 
-  Object.entries(data).forEach(([key, value]) =>
+  Object.entries(searchParams).forEach(([key, value]) =>
     Array.isArray(value)
       ? value.forEach((entry) => url.searchParams.append(key, entry.toString()))
       : url.searchParams.set(key, value.toString()),

--- a/deployables/app/app/vnet/server/api.ts
+++ b/deployables/app/app/vnet/server/api.ts
@@ -3,12 +3,12 @@ import type { z, ZodTypeAny } from 'zod'
 
 type VnetApiOptions<Schema extends ZodTypeAny> = {
   schema: Schema
-  data?: Record<string, string | number | boolean | string[] | number[]>
+  searchParams?: Record<string, string | number | boolean | string[] | number[]>
 }
 
 export const api = async <Schema extends ZodTypeAny>(
   endpoint: `/${string}`,
-  { schema, data = {} }: VnetApiOptions<Schema>,
+  { schema, searchParams = {} }: VnetApiOptions<Schema>,
 ) => {
   const { TENDERLY_ACCESS_KEY, TENDERLY_PROJECT, TENDERLY_USER } =
     getTenderlyCredentials()
@@ -18,7 +18,7 @@ export const api = async <Schema extends ZodTypeAny>(
       endpoint,
   )
 
-  Object.entries(data).forEach(([key, value]) => {
+  Object.entries(searchParams).forEach(([key, value]) => {
     if (Array.isArray(value)) {
       value.forEach((entry) => url.searchParams.append(key, entry.toString()))
     } else {

--- a/deployables/app/app/vnet/server/getVnetTransactions.ts
+++ b/deployables/app/app/vnet/server/getVnetTransactions.ts
@@ -3,7 +3,7 @@ import { api } from './api'
 
 export const getVnetTransactions = async (vnetId: string) => {
   return api(`/${vnetId}/transactions`, {
-    data: {
+    searchParams: {
       kind: 'blockchain',
       category: 'write',
       status: 'success',

--- a/deployables/app/app/vnet/server/getVnetTransactions.ts
+++ b/deployables/app/app/vnet/server/getVnetTransactions.ts
@@ -7,6 +7,7 @@ export const getVnetTransactions = async (vnetId: string) => {
       kind: 'blockchain',
       category: 'write',
       status: 'success',
+      per_page: 100,
     },
     schema: vnetTransactionsListSchema,
   })


### PR DESCRIPTION
By default the tenderly vnet API only returns 10 transactions at a time. By setting the page size explicitly this PR increases it so that the balances page will reflect all balance updates also for larger recorded bundles