### PR TITLE
feat(pilot-app): More address popovers

### DIFF
--- a/deployables/app/app/routes/submit/$route.$transactions/table/TokenApprovalTable.tsx
+++ b/deployables/app/app/routes/submit/$route.$transactions/table/TokenApprovalTable.tsx
@@ -1,5 +1,6 @@
 import { Token } from '@/components'
 import type { ApprovalTransaction } from '@/simulation-server'
+import { isHexAddress } from '@zodiac/schema'
 import {
   Address,
   Popover,
@@ -49,11 +50,29 @@ export function TokenApprovalTable({
         )}
 
         {approvals.map(
-          ({ symbol, logoUrl, spender, approvalAmount, decimals }, index) => {
+          (
+            {
+              symbol,
+              logoUrl,
+              spender,
+              tokenAddress,
+              approvalAmount,
+              decimals,
+            },
+            index,
+          ) => {
             return (
               <TableRow key={index}>
                 <TableCell>
-                  <Token logo={logoUrl}>{symbol}</Token>
+                  <Popover
+                    popover={
+                      isHexAddress(tokenAddress) && (
+                        <span className="text-sm">{tokenAddress}</span>
+                      )
+                    }
+                  >
+                    <Token logo={logoUrl}>{symbol}</Token>
+                  </Popover>
                 </TableCell>
 
                 <TableCell>

--- a/deployables/app/app/routes/submit/$route.$transactions/table/TokenTransferTable.tsx
+++ b/deployables/app/app/routes/submit/$route.$transactions/table/TokenTransferTable.tsx
@@ -1,8 +1,10 @@
 import type { TokenTransfer } from '@/balances-client'
 import { Token } from '@/components'
+import { isHexAddress } from '@zodiac/schema'
 import {
   Address,
   NumberValue,
+  Popover,
   Table,
   TableBody,
   TableCell,
@@ -60,56 +62,66 @@ export const TokenTransferTable = ({
           </TableRow>
         )}
 
-        {tokens.map(({ symbol, from, to, logoUrl, amount }, index) => {
-          const fromAvatar = from.toLowerCase() === avatarAddress
-          const toAvatar = to.toLowerCase() === avatarAddress
-          const isMint = from === ZeroAddress
-          const isBurn = to === ZeroAddress
+        {tokens.map(
+          ({ symbol, from, to, logoUrl, amount, contractId }, index) => {
+            const fromAvatar = from.toLowerCase() === avatarAddress
+            const toAvatar = to.toLowerCase() === avatarAddress
+            const isMint = from === ZeroAddress
+            const isBurn = to === ZeroAddress
 
-          return (
-            <TableRow key={index}>
-              <TableCell>
-                <Token logo={logoUrl}>{symbol}</Token>
-              </TableCell>
+            return (
+              <TableRow key={index}>
+                <TableCell>
+                  <Popover
+                    popover={
+                      isHexAddress(contractId) && (
+                        <span className="text-sm">{contractId}</span>
+                      )
+                    }
+                  >
+                    <Token logo={logoUrl}>{symbol}</Token>
+                  </Popover>
+                </TableCell>
 
-              <TableCell>
-                <div className="flex flex-col items-center gap-1 sm:flex-row sm:items-center sm:gap-2">
-                  {!fromAvatar && (
-                    <span className="whitespace-nowrap">
-                      {isMint ? (
-                        <span title={`${ZeroAddress} (mint)`}>🌱</span>
-                      ) : (
-                        <Address shorten size="small">
-                          {from}
-                        </Address>
-                      )}
-                    </span>
-                  )}
+                <TableCell>
+                  <div className="flex flex-col items-center gap-1 sm:flex-row sm:items-center sm:gap-2">
+                    {!fromAvatar && (
+                      <span className="whitespace-nowrap">
+                        {isMint ? (
+                          <span title={`${ZeroAddress} (mint)`}>🌱</span>
+                        ) : (
+                          <Address shorten size="small">
+                            {from}
+                          </Address>
+                        )}
+                      </span>
+                    )}
 
-                  {!fromAvatar && !toAvatar && (
-                    <span className="hidden sm:block">→</span>
-                  )}
+                    {!fromAvatar && !toAvatar && (
+                      <span className="hidden sm:block">→</span>
+                    )}
 
-                  {!toAvatar && (
-                    <span className="whitespace-nowrap">
-                      {isBurn ? (
-                        <span title={`${ZeroAddress} (burn)`}>🔥</span>
-                      ) : (
-                        <Address shorten size="small">
-                          {to}
-                        </Address>
-                      )}
-                    </span>
-                  )}
-                </div>
-              </TableCell>
+                    {!toAvatar && (
+                      <span className="whitespace-nowrap">
+                        {isBurn ? (
+                          <span title={`${ZeroAddress} (burn)`}>🔥</span>
+                        ) : (
+                          <Address shorten size="small">
+                            {to}
+                          </Address>
+                        )}
+                      </span>
+                    )}
+                  </div>
+                </TableCell>
 
-              <TableCell align="right" className="tabular-nums">
-                <NumberValue precision={4}>{amount}</NumberValue>
-              </TableCell>
-            </TableRow>
-          )
-        })}
+                <TableCell align="right" className="tabular-nums">
+                  <NumberValue precision={4}>{amount}</NumberValue>
+                </TableCell>
+              </TableRow>
+            )
+          },
+        )}
       </TableBody>
     </Table>
   )

--- a/deployables/app/app/routes/tokens/balances/balances.tsx
+++ b/deployables/app/app/routes/tokens/balances/balances.tsx
@@ -1,10 +1,12 @@
 import { useTokenBalances } from '@/balances-client'
 import { Token } from '@/components'
+import { isHexAddress } from '@zodiac/schema'
 import {
   Empty,
   Error as ErrorAlert,
   GhostLinkButton,
   Info,
+  Popover,
   SkeletonText,
   Table,
   TableBody,
@@ -68,7 +70,15 @@ const Balances = () => {
             }) => (
               <TableRow key={contractId} className="group">
                 <TableCell>
-                  <Token logo={logoUrl}>{name}</Token>
+                  <Popover
+                    popover={
+                      isHexAddress(contractId) && (
+                        <span className="text-sm">{contractId}</span>
+                      )
+                    }
+                  >
+                    <Token logo={logoUrl}>{name}</Token>
+                  </Popover>
                 </TableCell>
                 <TableCell align="right">
                   <TokenValue symbol={symbol} delta={diff?.amount}>

--- a/packages/ui/src/catalyst/Table.tsx
+++ b/packages/ui/src/catalyst/Table.tsx
@@ -170,10 +170,10 @@ export function TableCell({
           target={target}
           aria-label={title}
           tabIndex={cellRef?.previousElementSibling === null ? 0 : -1}
-          className="focus:outline-hidden absolute inset-0"
+          className="focus:outline-hidden absolute inset-0 z-0"
         />
       )}
-      {children}
+      <div className="z-1 pointer-events-auto relative">{children}</div>
     </td>
   )
 }


### PR DESCRIPTION
## Description
Closes #1276 

This PR introduces `Popover` tooltips for contract and account addresses when displaying ERC20 token data across key tables in the app:

- **Balances Page:** Token names now show a popover on hover with the full contract address.
- **Submit Page (Token Flows & Approvals sections):**
  - Token names in `TokenApprovalTable` and `TokenTransferTable` show the full token address in a popover.
  - A `Popover` is wrapped around the `Token` component where relevant.
- Fixed an issue where table row links were preventing hover events on shortened addresses by ensuring the clickable component (`<Link>`) has lower `z-index`, and wrapping content in a new relatively-positioned container.

<img width="998" alt="image" src="https://github.com/user-attachments/assets/c21e5e0e-91ef-4737-8207-cbb193ec9087" />
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/2faf3ca5-2c65-4421-9dd5-5b4a34af973e" />
<img width="832" alt="image" src="https://github.com/user-attachments/assets/f26ea16b-a178-43ac-8593-7cf3268fcc83" />
