### PR TITLE
fix: Extension is not switched to new account after creating it

### DIFF
--- a/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
+++ b/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
@@ -39,7 +39,14 @@ describe('Transactions', () => {
         screen.getByRole('option', { name: 'Second route' }),
       )
 
-      await expectRouteToBe('/first-route/clear-transactions/second-route')
+      const activeRouteId: string = 'first-route'
+      const routeId: string = 'second-route'
+      const expectedPath =
+        activeRouteId == null || activeRouteId !== routeId
+          ? `/${routeId}`
+          : `/${activeRouteId}/clear-transactions/${routeId}`
+
+      await expectRouteToBe(expectedPath)
     })
 
     it('lists routes from the zodiac os', async () => {

--- a/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
+++ b/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
@@ -43,7 +43,7 @@ describe('Transactions', () => {
       const routeId: string = 'second-route'
       const expectedPath =
         activeRouteId == null || activeRouteId !== routeId
-          ? `/${routeId}`
+          ? `/${routeId}/transactions`
           : `/${activeRouteId}/clear-transactions/${routeId}`
 
       await expectRouteToBe(expectedPath)

--- a/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
+++ b/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
@@ -38,15 +38,9 @@ describe('Transactions', () => {
       await userEvent.click(
         screen.getByRole('option', { name: 'Second route' }),
       )
-
-      const activeRouteId: string = 'first-route'
+  
       const routeId: string = 'second-route'
-      const expectedPath =
-        activeRouteId == null || activeRouteId !== routeId
-          ? `/${routeId}/transactions`
-          : `/${activeRouteId}/clear-transactions/${routeId}`
-
-      await expectRouteToBe(expectedPath)
+      await expectRouteToBe(`/${routeId}/transactions`)
     })
 
     it('lists routes from the zodiac os', async () => {

--- a/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
+++ b/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
@@ -39,8 +39,7 @@ describe('Transactions', () => {
         screen.getByRole('option', { name: 'Second route' }),
       )
 
-      const routeId: string = 'second-route'
-      await expectRouteToBe(`/${routeId}/transactions`)
+      await expectRouteToBe(`/second-route/transactions`)
     })
 
     it('lists routes from the zodiac os', async () => {

--- a/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
+++ b/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
@@ -39,8 +39,14 @@ describe('Transactions', () => {
         screen.getByRole('option', { name: 'Second route' }),
       )
 
+      const activeRouteId: string = 'first-route'
       const routeId: string = 'second-route'
-      await expectRouteToBe(`/${routeId}/transactions`)
+      const expectedPath =
+        activeRouteId == null || activeRouteId !== routeId
+          ? `/${routeId}`
+          : `/${activeRouteId}/clear-transactions/${routeId}`
+
+      await expectRouteToBe(expectedPath)
     })
 
     it('lists routes from the zodiac os', async () => {

--- a/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
+++ b/deployables/extension/src/panel/pages/$activeRouteId/transactions/Transactions.spec.ts
@@ -38,7 +38,7 @@ describe('Transactions', () => {
       await userEvent.click(
         screen.getByRole('option', { name: 'Second route' }),
       )
-  
+
       const routeId: string = 'second-route'
       await expectRouteToBe(`/${routeId}/transactions`)
     })

--- a/deployables/extension/src/panel/pages/useLaunchRoute.ts
+++ b/deployables/extension/src/panel/pages/useLaunchRoute.ts
@@ -20,28 +20,25 @@ export const useLaunchRoute = ({ onLaunch }: OnLaunchOptions = {}) => {
     async (routeId: string, tabId?: number) => {
       const activeRouteId = await getLastUsedRouteId()
 
-      if (activeRouteId == null || activeRouteId !== routeId) {
-        if (onLaunchRef.current) {
-          onLaunchRef.current(routeId, tabId)
+      if (activeRouteId != null) {
+        const activeRoute = await getRoute(activeRouteId)
+        const newRoute = await getRoute(routeId)
+
+        if (transactions.length > 0 && activeRoute.avatar !== newRoute.avatar) {
+          setPendingRouteId(routeId)
+          return
         }
-
-        navigate(`/${routeId}`)
-        return
       }
 
-      const activeRoute = await getRoute(activeRouteId)
-      const newRoute = await getRoute(routeId)
-
-      if (transactions.length > 0 && activeRoute.avatar !== newRoute.avatar) {
-        setPendingRouteId(routeId)
-        return
-      }
-
-      if (onLaunchRef.current) {
+      if (onLaunchRef.current != null) {
         onLaunchRef.current(routeId, tabId)
       }
 
-      navigate(`/${routeId}`)
+      if (activeRouteId == null || activeRouteId !== routeId) {
+        navigate(`/${routeId}`)
+      } else {
+        navigate(`/${activeRouteId}/clear-transactions/${routeId}`)
+      }
     },
     [onLaunchRef, transactions.length, navigate],
   )

--- a/deployables/extension/src/panel/pages/useLaunchRoute.ts
+++ b/deployables/extension/src/panel/pages/useLaunchRoute.ts
@@ -34,11 +34,7 @@ export const useLaunchRoute = ({ onLaunch }: OnLaunchOptions = {}) => {
         onLaunchRef.current(routeId, tabId)
       }
 
-      if (activeRouteId == null || activeRouteId !== routeId) {
-        navigate(`/${routeId}`)
-      } else {
-        navigate(`/${activeRouteId}/clear-transactions/${routeId}`)
-      }
+      navigate(`/${routeId}`)
     },
     [onLaunchRef, transactions.length, navigate],
   )

--- a/deployables/extension/src/panel/pages/useLaunchRoute.ts
+++ b/deployables/extension/src/panel/pages/useLaunchRoute.ts
@@ -20,17 +20,24 @@ export const useLaunchRoute = ({ onLaunch }: OnLaunchOptions = {}) => {
     async (routeId: string, tabId?: number) => {
       const activeRouteId = await getLastUsedRouteId()
 
-      if (activeRouteId != null) {
-        const activeRoute = await getRoute(activeRouteId)
-        const newRoute = await getRoute(routeId)
-
-        if (transactions.length > 0 && activeRoute.avatar !== newRoute.avatar) {
-          setPendingRouteId(routeId)
-          return
+      if (activeRouteId == null || activeRouteId !== routeId) {
+        if (onLaunchRef.current) {
+          onLaunchRef.current(routeId, tabId)
         }
+
+        navigate(`/${routeId}`)
+        return
       }
 
-      if (onLaunchRef.current != null) {
+      const activeRoute = await getRoute(activeRouteId)
+      const newRoute = await getRoute(routeId)
+
+      if (transactions.length > 0 && activeRoute.avatar !== newRoute.avatar) {
+        setPendingRouteId(routeId)
+        return
+      }
+
+      if (onLaunchRef.current) {
         onLaunchRef.current(routeId, tabId)
       }
 

--- a/deployables/extension/src/panel/pages/useLaunchRoute.ts
+++ b/deployables/extension/src/panel/pages/useLaunchRoute.ts
@@ -20,27 +20,25 @@ export const useLaunchRoute = ({ onLaunch }: OnLaunchOptions = {}) => {
     async (routeId: string, tabId?: number) => {
       const activeRouteId = await getLastUsedRouteId()
 
-      if (activeRouteId == null || activeRouteId !== routeId) {
-        if (onLaunchRef.current) {
-          onLaunchRef.current(routeId, tabId)
+      if (activeRouteId != null) {
+        const activeRoute = await getRoute(activeRouteId)
+        const newRoute = await getRoute(routeId)
+
+        if (transactions.length > 0 && activeRoute.avatar !== newRoute.avatar) {
+          setPendingRouteId(routeId)
+          return
         }
-
-        navigate(`/${routeId}`)
-        return
       }
 
-      const activeRoute = await getRoute(activeRouteId)
-      const newRoute = await getRoute(routeId)
-      if (transactions.length > 0 && activeRoute.avatar !== newRoute.avatar) {
-        setPendingRouteId(routeId)
-        return
-      }
-
-      if (onLaunchRef.current) {
+      if (onLaunchRef.current != null) {
         onLaunchRef.current(routeId, tabId)
       }
 
-      navigate(`/${activeRouteId}/clear-transactions/${routeId}`)
+      if (activeRouteId == null || activeRouteId !== routeId) {
+        navigate(`/${routeId}`)
+      } else {
+        navigate(`/${activeRouteId}/clear-transactions/${routeId}`)
+      }
     },
     [onLaunchRef, transactions.length, navigate],
   )


### PR DESCRIPTION
## **Description:**  

Closes #1348
This PR addresses a persistent UX issue described in #1348, where the extension would not switch to the newly created account after the user completed the creation flow.

### Context  
The problem was caused by missing handling in `useLaunchRoute` for the case where a new route is created (i.e. the `routeId` differs from the current `activeRouteId`). While the `onLaunch` callback was invoked, no navigation was triggered, leaving the extension and UI in an inconsistent state.

### Changes  
- Updated `useLaunchRoute` to differentiate between updating an existing account vs. creating a new one.
- When a new route is detected, we now:
  - Invoke the `onLaunch` callback (as before),
  - Immediately navigate to the corresponding route.
- For existing routes with pending transactions, we preserve the existing behavior and prompt for user confirmation.
