### PR TITLE
fix: hide chains without ser query support

### DIFF
--- a/deployables/app/app/routes-ui/ChainSelect.tsx
+++ b/deployables/app/app/routes-ui/ChainSelect.tsx
@@ -1,5 +1,5 @@
 import { invariant } from '@epic-web/invariant'
-import { CHAIN_HIDDEN, CHAIN_NAME, verifyChainId } from '@zodiac/chains'
+import { CHAIN_NAME, HIDDEN_CHAINS, verifyChainId } from '@zodiac/chains'
 import { Select } from '@zodiac/ui'
 import type { ChainId } from 'ser-kit'
 import { Chain } from './Chain'
@@ -18,7 +18,7 @@ const allOptions = Object.entries(CHAIN_NAME).map(([chainId, name]) => ({
 }))
 
 const visibleOptions = allOptions.filter(
-  (op) => !CHAIN_HIDDEN[op.value as keyof typeof CHAIN_HIDDEN],
+  (op) => !HIDDEN_CHAINS.includes(op.value),
 )
 
 export const ChainSelect = ({

--- a/deployables/app/app/routes-ui/ChainSelect.tsx
+++ b/deployables/app/app/routes-ui/ChainSelect.tsx
@@ -1,5 +1,5 @@
 import { invariant } from '@epic-web/invariant'
-import { CHAIN_NAME, verifyChainId } from '@zodiac/chains'
+import { CHAIN_HIDDEN, CHAIN_NAME, verifyChainId } from '@zodiac/chains'
 import { Select } from '@zodiac/ui'
 import type { ChainId } from 'ser-kit'
 import { Chain } from './Chain'
@@ -12,10 +12,14 @@ type ChainSelectProps = {
   name?: string
 }
 
-const options = Object.entries(CHAIN_NAME).map(([chainId, name]) => ({
+const allOptions = Object.entries(CHAIN_NAME).map(([chainId, name]) => ({
   value: verifyChainId(parseInt(chainId)),
   label: name,
 }))
+
+const visibleOptions = allOptions.filter(
+  (op) => !CHAIN_HIDDEN[op.value as keyof typeof CHAIN_HIDDEN],
+)
 
 export const ChainSelect = ({
   defaultValue,
@@ -23,26 +27,36 @@ export const ChainSelect = ({
   disabled,
   name,
   onChange,
-}: ChainSelectProps) => (
-  <Select
-    label="Chain"
-    isDisabled={disabled}
-    dropdownLabel="Select a different chain"
-    isMulti={false}
-    options={options}
-    name={name}
-    value={options.find((op) => op.value === value)}
-    defaultValue={options.find((op) => op.value === defaultValue)}
-    onChange={(option) => {
-      invariant(option != null, 'Empty value selected as chain')
+}: ChainSelectProps) => {
+  const valueOption = allOptions.find((op) => op.value === value)
+  const defaultValueOption = allOptions.find((op) => op.value === defaultValue)
+  const optionToShow = valueOption ?? defaultValueOption
+  const options =
+    !optionToShow || visibleOptions.includes(optionToShow)
+      ? visibleOptions
+      : [...visibleOptions, optionToShow]
 
-      if (onChange != null) {
-        onChange(option.value)
-      }
-    }}
-  >
-    {({ data: { label, value } }) => (
-      <Chain chainId={value}>{label || `#${value}`}</Chain>
-    )}
-  </Select>
-)
+  return (
+    <Select
+      label="Chain"
+      isDisabled={disabled}
+      dropdownLabel="Select a different chain"
+      isMulti={false}
+      options={options}
+      name={name}
+      value={valueOption}
+      defaultValue={defaultValueOption}
+      onChange={(option) => {
+        invariant(option != null, 'Empty value selected as chain')
+
+        if (onChange != null) {
+          onChange(option.value)
+        }
+      }}
+    >
+      {({ data: { label, value } }) => (
+        <Chain chainId={value}>{label || `#${value}`}</Chain>
+      )}
+    </Select>
+  )
+}

--- a/packages/chains/src/const.ts
+++ b/packages/chains/src/const.ts
@@ -104,8 +104,4 @@ export const CHAIN_NAME: Record<ChainId, string> = {
  * As long as ser does not support querying routes for a chain, we hide it from the chain select field.
  * That way we can support chains as long as users manually import their route using https://github.com/gnosisguild/build-pilot-route, for example.
  **/
-export const CHAIN_HIDDEN = {
-  [Chain.UNICHAIN]: true,
-  [Chain.WORLDCHAIN]: true,
-  [Chain.BOB]: true,
-}
+export const HIDDEN_CHAINS = [Chain.UNICHAIN, Chain.WORLDCHAIN, Chain.BOB]

--- a/packages/chains/src/const.ts
+++ b/packages/chains/src/const.ts
@@ -99,3 +99,13 @@ export const CHAIN_NAME: Record<ChainId, string> = {
   [Chain.WORLDCHAIN]: 'World Chain',
   [Chain.BOB]: 'BOB',
 }
+
+/**
+ * As long as ser does not support querying routes for a chain, we hide it from the chain select field.
+ * That way we can support chains as long as users manually import their route using https://github.com/gnosisguild/build-pilot-route, for example.
+ **/
+export const CHAIN_HIDDEN = {
+  [Chain.UNICHAIN]: true,
+  [Chain.WORLDCHAIN]: true,
+  [Chain.BOB]: true,
+}


### PR DESCRIPTION
small fix after we enabled some additional chains without ser query support with https://github.com/gnosisguild/zodiac-pilot/pull/1639.

we currently can't query routes for unichain, world chain and bob. but we can still let users manually build execution routes for these chains and import them into Pilot using https://github.com/gnosisguild/build-pilot-route.

to avoid confusing users we now hide these "half-supported" chains. they will be displayed and supported for manually imported routes but won't be suggested for route building to regular Pilot users.

