### PR TITLE
fix(zodiac-os): ens names should not overflow waypoints

### DIFF
--- a/deployables/app/app/routes-ui/Waypoints.tsx
+++ b/deployables/app/app/routes-ui/Waypoints.tsx
@@ -29,7 +29,7 @@ export const Waypoints = ({ children }: WaypointsProps) => {
     <ol
       className={classNames(
         'flex flex-1 items-center gap-4',
-        orientation === 'vertical' && 'flex-col',
+        orientation === 'vertical' && 'flex-col overflow-hidden',
       )}
     >
       {Children.map(children, (child, index) => (

--- a/packages/ui/src/addresses/Address.tsx
+++ b/packages/ui/src/addresses/Address.tsx
@@ -65,7 +65,15 @@ export const Address = ({
         )}
       />
       {label && (
-        <span className="whitespace-nowrap font-semibold">{label}</span>
+        <span
+          className={classNames(
+            'whitespace-nowrap font-semibold',
+            size === 'small' && 'text-xs',
+            size === 'tiny' && 'text-xs',
+          )}
+        >
+          {label}
+        </span>
       )}
       <code
         aria-hidden={label != null}
@@ -80,7 +88,11 @@ export const Address = ({
         {shorten ? (
           <Popover
             position="bottom"
-            popover={<Address size="small">{children}</Address>}
+            popover={
+              <Address label={ensName} size="small">
+                {children}
+              </Address>
+            }
           >
             {ensName == null ? <ShortAddress>{address}</ShortAddress> : ensName}
           </Popover>


### PR DESCRIPTION
Fixes #1893 