### PR TITLE
feat(companion-app): extension onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ To set up a development environment follow the steps outlaid in the readmes for 
 Zodiac Pilot is a browser-based tool for Safe accounts that enables users to build and execute multi-step transactions across multiple dapps.
 It combines modular batching, programmable permissions, and a built-in sandbox environment to simulate transactions before they’re sent onchain.
 Designed to streamline treasury, governance, and DeFi workflows, Pilot reduces risk and coordination overhead by letting users manage execution directly from a side panel interface.
-[Available on the Chrome Web Store](https://chrome.google.com/webstore/detail/zodiac-pilot/jklckajipokenkbbodifahogmidkekcb?hl=en&authuser=0)
+[Available on the Chrome Web Store](https://chrome.google.com/webstore/detail/zodiac-pilot/jklckajipokenkbbodifahogmidkekcb)

--- a/deployables/app/app/components/pilotStatus/PilotStatus.tsx
+++ b/deployables/app/app/components/pilotStatus/PilotStatus.tsx
@@ -1,10 +1,12 @@
 import { CompanionAppMessageType } from '@zodiac/messages'
-import { GhostButton } from '@zodiac/ui'
-import { PanelRightOpen, Power, PowerOff } from 'lucide-react'
+import { GhostButton, GhostLinkButton } from '@zodiac/ui'
+import { Chrome, PanelRightOpen, Power, PowerOff } from 'lucide-react'
 import { useConnected } from './PilotStatusContext'
+import { useIsExtensionInstalled } from './useIsExtensionInstalled'
 
 export const PilotStatus = () => {
   const connected = useConnected()
+  const installed = useIsExtensionInstalled()
 
   const openPilot = () => {
     window.postMessage({ type: CompanionAppMessageType.OPEN_PILOT }, '*')
@@ -21,21 +23,40 @@ export const PilotStatus = () => {
     )
   }
 
-  return (
-    <div className="flex justify-between gap-2">
-      <div className="flex items-center gap-2 text-xs font-semibold uppercase">
-        <PowerOff className="text-red-700" size={16} />
-        Disconnected
-      </div>
+  if (installed) {
+    return (
+      <div className="flex justify-between gap-2">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase">
+          <PowerOff className="text-red-700" size={16} />
+          Disconnected
+        </div>
 
-      <GhostButton
-        iconOnly
-        icon={PanelRightOpen}
-        size="tiny"
-        onClick={openPilot}
-      >
-        Open Pilot
-      </GhostButton>
-    </div>
+        <GhostButton
+          iconOnly
+          icon={PanelRightOpen}
+          size="tiny"
+          onClick={openPilot}
+        >
+          Open Pilot
+        </GhostButton>
+      </div>
+    )
+  }
+
+  // Still determining if extension is installed...
+  if (installed === undefined) {
+    return null
+  }
+
+  // Extension is not installed
+  return (
+    <GhostLinkButton
+      fluid
+      icon={Chrome}
+      to="https://chromewebstore.google.com/detail/zodiac-pilot/jklckajipokenkbbodifahogmidkekcb"
+      openInNewWindow
+    >
+      Install Extension
+    </GhostLinkButton>
   )
 }

--- a/deployables/app/app/components/pilotStatus/index.ts
+++ b/deployables/app/app/components/pilotStatus/index.ts
@@ -6,3 +6,4 @@ export {
   useConnected,
   useLastTransactionExecutedAt,
 } from './PilotStatusContext'
+export { useIsExtensionInstalled } from './useIsExtensionInstalled'

--- a/deployables/app/app/components/pilotStatus/useIsExtensionInstalled.tsx
+++ b/deployables/app/app/components/pilotStatus/useIsExtensionInstalled.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+import { useExtensionVersion } from '../versionManagement/ExtensionVersionContext'
+
+export const useIsExtensionInstalled = () => {
+  const version = useExtensionVersion()
+  const [hasWaited, setHasWaited] = useState(false)
+
+  // return undefined during the first 500ms to avoid flickering
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setHasWaited(true)
+    }, 500)
+
+    return () => clearTimeout(timer)
+  }, [])
+
+  // On server side, always return undefined
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  if (version != null) {
+    return true
+  }
+
+  return hasWaited ? false : undefined
+}

--- a/deployables/app/app/routes/launch/$prefixedAvatarAddress.$accountLabel/launch.tsx
+++ b/deployables/app/app/routes/launch/$prefixedAvatarAddress.$accountLabel/launch.tsx
@@ -1,4 +1,4 @@
-import { Page, useConnected } from '@/components'
+import { Page, useConnected, useIsExtensionInstalled } from '@/components'
 import { ChainSelect } from '@/routes-ui'
 import { useIsPending } from '@zodiac/hooks'
 import { CompanionAppMessageType, companionRequest } from '@zodiac/messages'
@@ -7,7 +7,14 @@ import {
   verifyPrefixedAddress,
   type ExecutionRoute,
 } from '@zodiac/schema'
-import { AddressInput, InlineForm, PrimaryButton, Warning } from '@zodiac/ui'
+import {
+  AddressInput,
+  InlineForm,
+  PrimaryButton,
+  PrimaryLinkButton,
+  Warning,
+} from '@zodiac/ui'
+import { Chrome } from 'lucide-react'
 import { splitPrefixedAddress } from 'ser-kit'
 import { z } from 'zod'
 import type { Route } from './+types/launch'
@@ -95,13 +102,14 @@ export default function LaunchPage({
   const isLaunching = useIsPending()
 
   const connected = useConnected()
+  const installed = useIsExtensionInstalled()
 
   const [chainId, address] = splitPrefixedAddress(route.avatar)
 
   return (
     <Page>
       <div className="flex h-full items-center justify-center">
-        <div className="flex flex-col items-center gap-4">
+        <div className="flex flex-col items-center gap-8">
           <div className="flex items-center gap-4">
             <ChainSelect disabled value={chainId} />
             <AddressInput
@@ -116,11 +124,24 @@ export default function LaunchPage({
               Launch will clear any previously recorded calls in the panel.
             </Warning>
           )}
-          <InlineForm>
-            <PrimaryButton submit busy={isLaunching}>
-              Launch
-            </PrimaryButton>
-          </InlineForm>
+
+          {installed === false && (
+            <PrimaryLinkButton
+              icon={Chrome}
+              to="https://chromewebstore.google.com/detail/zodiac-pilot/jklckajipokenkbbodifahogmidkekcb"
+              openInNewWindow
+            >
+              Install Zodiac Pilot
+            </PrimaryLinkButton>
+          )}
+
+          {installed !== false && (
+            <InlineForm>
+              <PrimaryButton submit busy={isLaunching}>
+                Launch
+              </PrimaryButton>
+            </InlineForm>
+          )}
         </div>
       </div>
     </Page>

--- a/deployables/app/app/routes/tokens/index.tsx
+++ b/deployables/app/app/routes/tokens/index.tsx
@@ -46,10 +46,8 @@ const Connected = ({ children }: PropsWithChildren) => {
       <Page.Main>
         <div className="mx-auto my-16 w-1/2">
           <Info title="Connected wallet needed">
-            The intended use of this page requires a wallet to be connected.
-            We've built it to easily test out the functionality offered by
-            Zodiac Pilot. When you open the extension it will automatically
-            connect to this page.
+            This page requires the Zodiac Pilot extension to be active. Open it
+            using the button below.
           </Info>
         </div>
 


### PR DESCRIPTION
We now show clearly if the Zodiac Pilot extension is not yet installed and offer a link to the Chrome Web Store.

This is getting more important as Zodiac OS becomes the primary entrypoint and the extension acts more to progressively enhance the user experience for Zodiac OS users. Also in the context of Railgun Connect (#1957), first-time users are now guided clearly through the initial set up flow. 